### PR TITLE
feat: add adjustment features for sales, purchase, cashbook, and sync…

### DIFF
--- a/app/Console/Commands/SyncAccountingDaily.php
+++ b/app/Console/Commands/SyncAccountingDaily.php
@@ -3,146 +3,191 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
 use App\Models\MstRule;
-use App\Models\MstAccountCodes;
+use App\Models\GeneralLedger;
 use App\Models\ReportMonthly;
-use Carbon\Carbon;
+use App\Models\MstAccountCodes;
+use Illuminate\Support\Facades\Log;
 
 class SyncAccountingDaily extends Command
 {
-    protected $signature = 'sync:accounting-daily';
-    protected $description = 'Sync accounting data daily based on rule time';
+    protected $signature    = 'sync:accounting-daily';
+    protected $description  = 'Sync accounting data daily based on rule time';
 
     public function handle()
     {
         $this->log('--- Starting Sync Accounting Daily ---');
+        $this->log('--------------------------------------');
 
-        // --- 1. Scheduler logic starts here ---
-        $currentPeriod  = now()->format('Y-m');
-        $previousPeriod = now()->subMonth()->format('Y-m');
-
-        // 1a. First run? (report_monthly empty)
-        if (!ReportMonthly::exists()) {
-            $this->firstInitialization($currentPeriod);
-            $this->log('Monthly report initialized for first run.');
-            return Command::SUCCESS;
+        $rule = MstRule::where('rule_name', 'Recalculate All')->first();
+        if ($rule && $rule->rule_value == 0) {
+            // RECALCULATE LAST TWO MONTH
+            $this->log('RECALCULATE REPORT FOR THE LAST TWO MONTHS.');
+            $prevDate = \Carbon\Carbon::now()->startOfMonth()->subMonth()->format('Y-m-d H:i:s');
+            $this->recalculateReportInit($prevDate);
+        } else {
+            // RECALCULATE ALL TRANSACTION
+            $this->log('RECALCULATE REPORT FROM FIRST TRANSACTION.');
+            $minTransDate = GeneralLedger::min('date_transaction');
+            if (!$minTransDate) { 
+                $this->log('--- No Transaction Yet ---');
+                $this->log('--------------------------------------');
+                $this->log('--- End Sync Accounting Daily ---');
+                return Command::SUCCESS;
+            }
+            $isAllSuccess = $this->recalculateReportInit($minTransDate);
+            if ($isAllSuccess) {
+                MstRule::updateOrCreate(
+                    ['rule_name'  => 'Recalculate All'],
+                    ['rule_value' => 0]
+                );
+            }
         }
-
-        // 1b. First day of month? open current month by get amount close prev month
-        $today = now();
-        if ($today->day === 1) {
-            $this->log("First day of month. Opening current month: {$currentPeriod}");
-            $this->openCurrentMonth($currentPeriod, $previousPeriod);
-        }
-
-        // 1c. Ensure new accounts mid-month
-        $this->log("Checking for new accounts for current period: {$currentPeriod}");
-        $this->ensureNewAccounts($currentPeriod);
-
-        // 1d. Update current month closing balance daily
-        $this->log("Updating current month closing balance: {$currentPeriod}");
-        $this->updateCurrentMonthClosing($currentPeriod);
-
-        $this->log('Accounting data synced successfully.');
+        
+        $this->log('--------------------------------------');
         $this->log('--- End Sync Accounting Daily ---');
-
         return Command::SUCCESS;
     }
 
-    // --- Helper methods ---
-
-    private function firstInitialization($period)
+    private function recalculateReportInit($minTransDate)
     {
-        $accounts = MstAccountCodes::all();
-
-        foreach ($accounts as $account) {
-            ReportMonthly::create([
-                'id_account_code' => $account->id,
-                'period' => $period,
-                'opening_balance' => $account->opening_balance,
-                'opening_balance_type' => $account->opening_balance_type,
-                'closing_balance' => $account->balance,
-                'closing_balance_type' => $account->balance_type,
-            ]);
+        if (!$minTransDate) {
+            return false;
         }
-    }
 
-    private function openCurrentMonth($currentPeriod, $previousPeriod)
-    {
-        $accounts = MstAccountCodes::all();
+        $startDate   = \Carbon\Carbon::parse($minTransDate)->startOfMonth();
+        $currentDate = \Carbon\Carbon::now()->startOfMonth();
 
-        foreach ($accounts as $account) {
-            $exists = ReportMonthly::where('period', $currentPeriod)
-                ->where('id_account_code', $account->id)
-                ->exists();
+        while ($startDate <= $currentDate) {
+            $period = $startDate->format('Y-m');
 
-            if ($exists) continue;
+            try {
+                $this->log("PERIOD {$period} START");
 
-            $lastMonth = ReportMonthly::where('period', $previousPeriod)
-                ->where('id_account_code', $account->id)
-                ->first();
+                DB::transaction(function () use ($startDate, $period) {
+                    $startMonth = $startDate->copy()->startOfMonth();
+                    $endMonth   = $startDate->copy()->endOfMonth();
 
-            if ($lastMonth) {
-                $openingBalance = $lastMonth->closing_balance;
-                $openingType    = $lastMonth->closing_balance_type;
-            } else {
-                $openingBalance = $account->opening_balance;
-                $openingType    = $account->opening_balance_type;
+                    $accountCodes = MstAccountCodes::where('created_at', '<=', $endMonth)->get();
+
+                    // GET ALL TRANSACTIONS THIS MONTH ONCE
+                    $transactions = GeneralLedger::select('id_account_code', 'amount', 'transaction')
+                        ->whereBetween('date_transaction', [$startMonth, $endMonth])
+                        ->get()
+                        ->groupBy('id_account_code');
+
+                    // GET PREVIOUS REPORTS ONCE
+                    $prevPeriod = $startDate->copy()->subMonth()->format('Y-m');
+                    $prevReports = ReportMonthly::where('period', $prevPeriod)->get()->keyBy('id_account_code');
+
+                    // GET ID ACCOUNT CODE THAT HAS REALLY RUNNING TRANSACTION IN PERIOD BEFORE
+                    $accountHasTransactionBefore = GeneralLedger::where('date_transaction', '<', $startMonth)
+                        ->distinct()
+                        ->pluck('id_account_code')
+                        ->toArray();
+
+                    foreach ($accountCodes as $account) {
+                        $isAnyTransactionBefore = in_array($account->id, $accountHasTransactionBefore);
+                        if (!$isAnyTransactionBefore) {
+                            // For Case: When In This Period User Edit Opening Balance Master Account Code (account code has not running in period before)
+                            $openingBalance     = (float) $account->opening_balance;
+                            $openingBalanceType = $account->opening_balance_type;
+                        } else {
+                            $prevReport         = $prevReports[$account->id] ?? null;
+                            $openingBalance     = $prevReport ? (float) $prevReport->closing_balance : (float) $account->opening_balance;
+                            $openingBalanceType = $prevReport ? $prevReport->closing_balance_type : $account->opening_balance_type;
+                        }
+
+                        $closingBalance     = $openingBalance;
+                        $closingBalanceType = $openingBalanceType;
+
+                        $transThisPeriods = $transactions[$account->id] ?? collect();
+
+                        foreach ($transThisPeriods as $trans) {
+                            if (!$trans->amount) {
+                                continue;
+                            }
+
+                            $transAmount     = (float) $trans->amount;
+                            $transAmountType = $trans->transaction;
+
+                            if ($closingBalanceType === $transAmountType) {
+                                $closingBalance += $transAmount;
+                            } else {
+                                $result = $closingBalance - $transAmount;
+                                if ($result > 0) {
+                                    $closingBalance = $result;
+                                } elseif ($result < 0) {
+                                    $closingBalance     = abs($result);
+                                    $closingBalanceType = $transAmountType;
+                                } else {
+                                    $closingBalance     = 0;
+                                    $closingBalanceType = 'D';
+                                }
+                            }
+                        }
+
+                        // Find existing monthly report or create new model instance (not saved yet)
+                        $report = ReportMonthly::firstOrNew([
+                            'id_account_code' => $account->id,
+                            'period'          => $period,
+                        ]);
+
+                        $normalize = fn($v) => number_format((float)$v, 3, '.', '');
+                        // New calculated values for this period
+                        $newData = [
+                            'opening_balance'      => $normalize($openingBalance),
+                            'opening_balance_type' => $openingBalanceType,
+                            'closing_balance'      => $normalize($closingBalance),
+                            'closing_balance_type' => $closingBalanceType,
+                        ];
+                        // Current DB values (if record exists), If record is new (firstOrNew), these will be NULL/default values
+                        $currentData = [
+                            'opening_balance'      => $normalize($report->opening_balance),
+                            'opening_balance_type' => $report->opening_balance_type,
+                            'closing_balance'      => $normalize($report->closing_balance),
+                            'closing_balance_type' => $report->closing_balance_type,
+                        ];
+
+                        // Compare FULL dataset
+                        // - If record is new → values differ (NULL vs new values) → TRUE
+                        // - If any field changes → TRUE
+                        // - If exactly same → FALSE
+                        $isChanged = $newData !== $currentData;
+
+                        // Only insert/update when: record does not exist yet (new row) OR data has changed
+                        if ($isChanged) {
+                            // Fill model with new values
+                            $report->fill($newData);
+                            // Save will: INSERT if new record UPDATE if existing record
+                            $report->save();
+
+                            $this->log("- Update Report Account Code ID: {$account->id}");
+                        }
+                    }
+                });
+
+                $this->log("PERIOD {$period} RECALCULATED");
+
+            } catch (\Throwable $e) {
+                $this->log("PERIOD {$period} FAILED RECALCULATE");
+                $this->log($e->getMessage());
+                return false;
             }
 
-            ReportMonthly::create([
-                'id_account_code' => $account->id,
-                'period' => $currentPeriod,
-                'opening_balance' => $openingBalance,
-                'opening_balance_type' => $openingType,
-                'closing_balance' => $openingBalance,
-                'closing_balance_type' => $openingType,
-            ]);
+            $startDate->addMonth();
         }
-    }
 
-    private function ensureNewAccounts($period)
-    {
-        $accounts = MstAccountCodes::all();
-
-        foreach ($accounts as $account) {
-            $exists = ReportMonthly::where('period', $period)
-                ->where('id_account_code', $account->id)
-                ->exists();
-
-            if (!$exists) {
-                ReportMonthly::create([
-                    'id_account_code' => $account->id,
-                    'period' => $period,
-                    'opening_balance' => $account->opening_balance,
-                    'opening_balance_type' => $account->opening_balance_type,
-                    'closing_balance' => $account->balance,
-                    'closing_balance_type' => $account->balance_type,
-                ]);
-            }
-        }
-    }
-
-    // --- Daily closing snapshot ---
-    private function updateCurrentMonthClosing($period)
-    {
-        $reports = ReportMonthly::where('period', $period)->get();
-
-        foreach ($reports as $report) {
-            $account = MstAccountCodes::find($report->id_account_code);
-
-            if ($account) {
-                $report->update([
-                    'closing_balance'      => $account->balance,
-                    'closing_balance_type' => $account->balance_type,
-                ]);
-            }
-        }
+        return true;
     }
 
     // --- Logging helper ---
     private function log($message)
     {
-        $this->info('[' . now()->format('Y-m-d H:i:s') . '] ' . $message);
+        $formatted = '[' . now()->format('Y-m-d H:i:s') . '] ' . $message;
+        $this->info($formatted);
+        Log::info($formatted);
     }
 }

--- a/app/Console/Commands/SyncAccountingDailyOld.php
+++ b/app/Console/Commands/SyncAccountingDailyOld.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use App\Models\MstAccountCodes;
+use App\Models\ReportMonthly;
+
+class SyncAccountingDailyOld extends Command
+{
+    protected $signature = 'sync:accounting-daily-old';
+    protected $description = 'Sync accounting data daily based on rule time';
+
+    public function handle()
+    {
+        $this->log('--- Starting Sync Accounting Daily ---');
+
+        // --- 1. Scheduler logic starts here ---
+        $currentPeriod  = now()->format('Y-m');
+        $previousPeriod = now()->subMonth()->format('Y-m');
+
+        // 1a. First run? (report_monthly empty)
+        if (!ReportMonthly::exists()) {
+            $this->firstInitialization($currentPeriod);
+            $this->log('Monthly report initialized for first run.');
+            return Command::SUCCESS;
+        }
+
+        // 1b. First day of month? open current month by get amount close prev month
+        $today = now();
+        if ($today->day === 1) {
+            $this->log("First day of month. Opening current month: {$currentPeriod}");
+            $this->openCurrentMonth($currentPeriod, $previousPeriod);
+        }
+
+        // 1c. Ensure new accounts mid-month
+        $this->log("Checking for new accounts for current period: {$currentPeriod}");
+        $this->ensureNewAccounts($currentPeriod);
+
+        // 1d. Update current month closing balance daily
+        $this->log("Updating current month closing balance: {$currentPeriod}");
+        $this->updateCurrentMonthClosing($currentPeriod);
+
+        $this->log('Accounting data synced successfully.');
+        $this->log('--- End Sync Accounting Daily ---');
+
+        return Command::SUCCESS;
+    }
+
+    // --- Helper methods ---
+
+    private function firstInitialization($period)
+    {
+        $accounts = MstAccountCodes::all();
+
+        foreach ($accounts as $account) {
+            ReportMonthly::create([
+                'id_account_code' => $account->id,
+                'period' => $period,
+                'opening_balance' => $account->opening_balance,
+                'opening_balance_type' => $account->opening_balance_type,
+                'closing_balance' => $account->balance,
+                'closing_balance_type' => $account->balance_type,
+            ]);
+        }
+    }
+
+    private function openCurrentMonth($currentPeriod, $previousPeriod)
+    {
+        $accounts = MstAccountCodes::all();
+
+        foreach ($accounts as $account) {
+            $exists = ReportMonthly::where('period', $currentPeriod)
+                ->where('id_account_code', $account->id)
+                ->exists();
+
+            if ($exists) continue;
+
+            $lastMonth = ReportMonthly::where('period', $previousPeriod)
+                ->where('id_account_code', $account->id)
+                ->first();
+
+            if ($lastMonth) {
+                $openingBalance = $lastMonth->closing_balance;
+                $openingType    = $lastMonth->closing_balance_type;
+            } else {
+                $openingBalance = $account->opening_balance;
+                $openingType    = $account->opening_balance_type;
+            }
+
+            ReportMonthly::create([
+                'id_account_code' => $account->id,
+                'period' => $currentPeriod,
+                'opening_balance' => $openingBalance,
+                'opening_balance_type' => $openingType,
+                'closing_balance' => $openingBalance,
+                'closing_balance_type' => $openingType,
+            ]);
+        }
+    }
+
+    private function ensureNewAccounts($period)
+    {
+        $accounts = MstAccountCodes::all();
+
+        foreach ($accounts as $account) {
+            $exists = ReportMonthly::where('period', $period)
+                ->where('id_account_code', $account->id)
+                ->exists();
+
+            if (!$exists) {
+                ReportMonthly::create([
+                    'id_account_code' => $account->id,
+                    'period' => $period,
+                    'opening_balance' => $account->opening_balance,
+                    'opening_balance_type' => $account->opening_balance_type,
+                    'closing_balance' => $account->balance,
+                    'closing_balance_type' => $account->balance_type,
+                ]);
+            }
+        }
+    }
+
+    // --- Daily closing snapshot ---
+    private function updateCurrentMonthClosing($period)
+    {
+        $reports = ReportMonthly::where('period', $period)->get();
+
+        foreach ($reports as $report) {
+            $account = MstAccountCodes::find($report->id_account_code);
+
+            if ($account) {
+                $report->update([
+                    'closing_balance'      => $account->balance,
+                    'closing_balance_type' => $account->balance_type,
+                ]);
+            }
+        }
+    }
+
+    // --- Logging helper ---
+    private function log($message)
+    {
+        $this->info('[' . now()->format('Y-m-d H:i:s') . '] ' . $message);
+    }
+}

--- a/app/Http/Controllers/GeneralLedgersController.php
+++ b/app/Http/Controllers/GeneralLedgersController.php
@@ -70,8 +70,14 @@ class GeneralLedgersController extends Controller
                 $datas = $datas->whereDate('general_ledgers.created_at','>=',$startdate)->whereDate('general_ledgers.created_at','<=',$enddate);
             }
             
-            if($request->flag != null){
-                $datas = $datas->get()->makeHidden(['id']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             

--- a/app/Http/Controllers/MstAccountCodesController.php
+++ b/app/Http/Controllers/MstAccountCodesController.php
@@ -59,8 +59,14 @@ class MstAccountCodesController extends Controller
                 $datas = $datas->whereDate('master_account_codes.created_at','>=',$startdate)->whereDate('master_account_codes.created_at','<=',$enddate);
             }
             
-            if($request->flag != null){
-                $datas = $datas->get()->makeHidden(['id', 'id_master_account_types']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['id_master_account_types'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             

--- a/app/Http/Controllers/MstAccountTypesController.php
+++ b/app/Http/Controllers/MstAccountTypesController.php
@@ -46,8 +46,14 @@ class MstAccountTypesController extends Controller
                 $datas = $datas->whereDate('created_at','>=',$startdate)->whereDate('created_at','<=',$enddate);
             }
             
-            if($request->flag != null){
-                $datas = $datas->orderBy('master_account_types.created_at','asc')->get()->makeHidden(['id']);
+            if ($request->flag != null) {
+                $datas = $datas->orderBy('master_account_types.created_at','asc')->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -47,8 +47,13 @@ class ReportController extends Controller
                 $datas = $datas->where('account_name', 'like', '%'.$account_name.'%');
             }
 
-            if($request->flag != null){
-                $datas = $datas->get()->makeHidden(['id', 'id_account_code', 'created_at', 'updated_at']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['id_account_code'], $data['created_at'], $data['updated_at']);
+                    $data['last_updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
                 

--- a/app/Http/Controllers/TransCashBookController.php
+++ b/app/Http/Controllers/TransCashBookController.php
@@ -114,8 +114,14 @@ class TransCashBookController extends Controller
                 $datas = $datas->whereDate('trans_cash_book.created_at','>=',$startdate)->whereDate('trans_cash_book.created_at','<=',$enddate);
             }
             
-            if($request->flag != null){
-                $datas = $datas->get()->makeHidden(['id', 'id_master_bank_account', 'total_transaction']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['id_master_bank_account'], $data['total_transaction'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             
@@ -133,25 +139,36 @@ class TransCashBookController extends Controller
         return view('cashbook.index',compact('typeManuals', 'trans_number', 'invoice_number', 'tax_invoice_number', 'type', 'searchDate', 'startdate', 'enddate', 'flag'));
     }
 
-    public function generateCBNumber($type, $codeBank = null, $currency = null)
+    public function generateCBNumber($type, $codeBank = null, $currency = null, $dateInvoice = null)
     {
-        $year  = date('y');
-        $month = now()->format('n');
+        $date  = $dateInvoice ? strtotime($dateInvoice) : time();
+        $Year  = date('Y', $date);
+        $year  = date('y', $date);
+        $month = date('m', $date);
+
         $romanMonths = [
-            1 => 'I', 2 => 'II', 3 => 'III', 4 => 'IV',
-            5 => 'V', 6 => 'VI', 7 => 'VII', 8 => 'VIII',
-            9 => 'IX', 10 => 'X', 11 => 'XI', 12 => 'XII',
+            '01' => 'I',
+            '02' => 'II',
+            '03' => 'III',
+            '04' => 'IV',
+            '05' => 'V',
+            '06' => 'VI',
+            '07' => 'VII',
+            '08' => 'VIII',
+            '09' => 'IX',
+            '10' => 'X',
+            '11' => 'XI',
+            '12' => 'XII'
         ];
 
-        // Get last sequence for current month & year
-        $lastData = TransCashBook::where('type', $type)
-            ->whereMonth('created_at', now()->month)
-            ->whereYear('created_at', now()->year)
-            ->latest('created_at')
-            ->first();
-        $seq = $lastData ? $lastData->seq + 1 : 1;
+        // Get max sequence from dateInvoice
+        $maxSeq = TransCashBook::where('type', $type)
+            ->whereMonth('date_invoice', $month)
+            ->whereYear('date_invoice', $Year)
+            ->max('seq');
+        $seq = ($maxSeq ?? 0) + 1;
         $seqFormatted = str_pad($seq, 4, '0', STR_PAD_LEFT);
-
+        
         // Determine transaction code
         switch ($type) {
             case 'Bukti Kas Keluar':
@@ -198,7 +215,7 @@ class TransCashBookController extends Controller
     {
         // dd(($request->all()));
         $request->validate([
-            'date_invoice'           => 'required',
+            'date_invoice'           => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
             'invoice_number'         => 'required',
             'tax_invoice_number'     => 'required',
             'type'                   => 'required',
@@ -220,7 +237,7 @@ class TransCashBookController extends Controller
             $category    = "KAS";
         }
 
-        $genNumber   = $this->generateCBNumber($type, $codeBank, $currency);
+        $genNumber   = $this->generateCBNumber($type, $codeBank, $currency, $request->date_invoice ?? null);
         $transNumber = $genNumber['trans_number'];
         $seqNumber   = $genNumber['seq_number'];
 
@@ -302,6 +319,11 @@ class TransCashBookController extends Controller
     {
         $id = decrypt($id);
         $detail = TransCashBook::where('id', $id)->first();
+        if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+            return redirect()->route('cashbook.index')->with([
+                'fail' => 'Transactions can only be edited within 20 days prior to the current date.'
+            ]);
+        }
         $bankAccountsUsed = MstBankAccount::where('id', $detail->id_master_bank_account)->first();
         $generalLedgers = GeneralLedger::select('general_ledgers.*', 'master_account_codes.account_code', 'master_account_codes.account_name')
             ->leftjoin('master_account_codes', 'general_ledgers.id_account_code', 'master_account_codes.id')
@@ -321,7 +343,7 @@ class TransCashBookController extends Controller
     {
         // dd($request->all());
         $request->validate([
-            'date_invoice'              => 'required',
+            'date_invoice'              => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
             'invoice_number'            => 'required',
             'tax_invoice_number'        => 'required',
             'addmore.*.account_code'    => 'required',
@@ -331,15 +353,11 @@ class TransCashBookController extends Controller
         
         $id          = decrypt($id);
         $detail      = TransCashBook::where('id', $id)->lockForUpdate()->first();
+        $seqNumber   = $detail->seq;
         $transNumber = $detail->transaction_number;
         $invNumber   = $request->invoice_number;
         
         // Validation
-        $trxDate = Carbon::parse($detail->date_invoice);
-        $now     = Carbon::now();
-        if (!$trxDate->isSameMonth($now)) {
-            return back()->with('error', 'This transaction cannot be updated because the transaction month has already passed.');
-        }
         $isDuplicate = TransCashBook::where('invoice_number', $invNumber)->where('id', '!=', $id)->exists();
         if ($isDuplicate) {
             return back()->withInput()->with(['error' => 'Invoice number already in use, please use another invoice number']);
@@ -364,6 +382,9 @@ class TransCashBookController extends Controller
             $transactionType = 'K';
             $totalAmount = abs($total);
         }
+
+        $monthDetail  = \Carbon\Carbon::parse($detail->date_invoice)->month;
+        $monthRequest = \Carbon\Carbon::parse($request->date_invoice)->month;
         
         $detail->date_invoice       = $request->date_invoice . ' 00:00:00';
         $detail->invoice_number     = $invNumber;
@@ -397,7 +418,22 @@ class TransCashBookController extends Controller
             DB::beginTransaction();
             try{
                 if($isChangedDetail) {
+
+                    if ($monthDetail != $monthRequest) {
+                        $genNumber      = $this->generateCBNumber($detail->type, $detail->codeBank, $detail->currency, $request->date_invoice);
+                        $transNumberNew = $genNumber['trans_number'];
+                        $seqNumber      = $genNumber['seq_number'];
+
+                        GeneralLedger::where('id_ref', $id)->where('ref_number', $transNumber)->where('source', 'Cash Book')->update([
+                            'ref_number' => $transNumberNew
+                        ]);
+
+                        $transNumber = $transNumberNew;
+                    }
+
                     TransCashBook::where('id', $id)->update([
+                        'seq'                => $seqNumber,
+                        'transaction_number' => $transNumber,
                         'invoice_number'     => $invNumber,
                         'tax_invoice_number' => $request->tax_invoice_number,
                         'date_invoice'       => $request->date_invoice,
@@ -453,11 +489,10 @@ class TransCashBookController extends Controller
             $id = decrypt($id);
             $detail  = TransCashBook::findOrFail($id);
 
-            // Validation
-            $trxDate = Carbon::parse($detail->date_invoice);
-            $now     = Carbon::now();
-            if (!$trxDate->isSameMonth($now)) {
-                return back()->with('error', 'This transaction cannot be deleted because the transaction month has already passed.');
+            if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+                return redirect()->route('cashbook.index')->with([
+                    'fail' => 'Transactions can only be deleted within 20 days prior to the current date.'
+                ]);
             }
 
             $generalLedgers = GeneralLedger::where('id_ref', $id)

--- a/app/Http/Controllers/TransDataBankController.php
+++ b/app/Http/Controllers/TransDataBankController.php
@@ -58,8 +58,14 @@ class TransDataBankController extends Controller
             $datas = $datas->whereDate('created_at','>=',$startdate)->whereDate('created_at','<=',$enddate);
         }
         
-        if($request->flag != null){
-            $datas = $datas->get()->makeHidden(['id']);
+        if ($request->flag != null) {
+            $datas = $datas->get()->map(function ($item) {
+                $data = $item->toArray();
+                unset($data['id'], $data['created_at'], $data['updated_at']);
+                $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                return $data;
+            });
             return $datas;
         }
 

--- a/app/Http/Controllers/TransPurchaseController.php
+++ b/app/Http/Controllers/TransPurchaseController.php
@@ -115,6 +115,31 @@ class TransPurchaseController extends Controller
     {
         $idGRN      = $request->idGRN;
         $ppnRate    = $request->ppnRate;
+        $rule       = $request->rule;
+        
+        $isCoretax  = ($rule === "Coretax");
+
+        $coretax = function ($expression) use ($isCoretax) {
+            if (!$isCoretax) {
+                return "ROUND($expression, 3)";
+            }
+
+            return "
+                CASE 
+                    WHEN (($expression) - FLOOR(($expression))) >= 0.5 
+                        THEN CEIL(($expression))
+                    ELSE FLOOR(($expression))
+                END
+            ";
+        };
+
+        $basePrice = "
+            COALESCE(
+                purchase_requisition_details.price,
+                purchase_order_details.price
+            )
+        ";
+        $roundedPrice = $coretax($basePrice);
 
         $datas = GoodReceiptNoteDetail::select(
                 'good_receipt_note_details.id',
@@ -137,25 +162,32 @@ class TransPurchaseController extends Controller
                         purchase_order_details.currency
                     ) as currency
                 "),
+
+                // =========================
+                // PRICE ORIGIN
+                // =========================
                 DB::raw("
-                    COALESCE(
-                        purchase_requisition_details.price,
-                        purchase_order_details.price
-                    ) as price_origin
+                    {$roundedPrice} as price_origin
                 "),
+
+                // =========================
+                // PRICE
+                // =========================
                 DB::raw("
-                    COALESCE(
-                        purchase_requisition_details.price,
-                        purchase_order_details.price
-                    ) as price
+                    {$roundedPrice} as price
                 "),
+
+                // =========================
+                // TOTAL PRICE
+                // rounded price × qty → final rounded
+                // =========================
                 DB::raw("
-                    (
-                        COALESCE(
-                            purchase_requisition_details.price,
-                            purchase_order_details.price
-                        ) * good_receipt_note_details.receipt_qty
-                    ) as total_price
+                    {$coretax("
+                        (
+                            {$roundedPrice}
+                            * good_receipt_note_details.receipt_qty
+                        )
+                    ")} as total_price
                 ")
             )
             ->leftJoin('master_raw_materials', function ($join) {
@@ -191,9 +223,16 @@ class TransPurchaseController extends Controller
             ->whereNotNull('good_receipt_note_details.status')
             ->get();
 
-        $totalPrice     = round((float) $datas->sum('total_price'), 2);
-        $ppnValue       = round((float) ($ppnRate/100) * $totalPrice, 2);
-        $total          = round((float) $totalPrice + $ppnValue, 2);
+
+        if ($isCoretax) {
+            $totalPrice = round((float) $datas->sum('total_price'));
+            $ppnValue   = round(((float) $ppnRate / 100) * $totalPrice);
+            $total      = round($totalPrice + $ppnValue);
+        } else {
+            $totalPrice     = round((float) $datas->sum('total_price'), 2);
+            $ppnValue       = round((float) ($ppnRate/100) * $totalPrice, 2);
+            $total          = round((float) $totalPrice + $ppnValue, 2);
+        }
 
         if ($request->ajax()) {
             return DataTables::of($datas)
@@ -223,11 +262,11 @@ class TransPurchaseController extends Controller
             return DataTables::of($datas)
                 ->with([
                     'currency'  => $data->currency,
-                    'nj'        => round((float) $data->amount, 2),
+                    'nj'        => round((float) $data->amount),
                     'ppn_rate'  => $data->ppn_rate,
-                    'ppn'       => round((float) $data->ppn_value, 2),
-                    'discount'  => round((float) $data->total_discount, 2),
-                    'total'     => round((float) $data->total, 2),
+                    'ppn'       => round((float) $data->ppn_value),
+                    'discount'  => round((float) $data->total_discount),
+                    'total'     => round((float) $data->total),
                 ])
                 ->toJson();
         }
@@ -273,8 +312,14 @@ class TransPurchaseController extends Controller
                 $datas = $datas->whereDate('trans_purchase.created_at','>=',$startdate)->whereDate('trans_purchase.created_at','<=',$enddate);
             }
             
-            if($request->flag != null){
-                $datas = $datas->get()->makeHidden(['id']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             
@@ -310,7 +355,7 @@ class TransPurchaseController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'date_invoice'              => 'required',
+            'date_invoice'              => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
             'id_good_receipt_notes'     => 'required',
             'grn_number'                => 'required',
             'grn_date'                  => 'required',
@@ -333,6 +378,7 @@ class TransPurchaseController extends Controller
         }
         $listProduct = json_decode($request->listProduct, true);
         $disc        = $this->normalizePrice($request->discount);
+        $disc        = $this->coretaxRound($disc);
 
         $lastStatusGRN = optional(GoodReceiptNote::where('id', $idGRN)->first())->status;
 
@@ -412,6 +458,12 @@ class TransPurchaseController extends Controller
     {
         $id = decrypt($id);
         $detail = TransPurchase::where('id', $id)->first();
+        if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+            return redirect()->route('transpurchase.index')->with([
+                'fail' => 'Transactions can only be edited within 20 days prior to the current date.'
+            ]);
+        }
+
         $detailTrans = TransPurchaseDetailPrice::where('id_trans_purchase', $id)->get();
         $generalLedgers = GeneralLedger::select('general_ledgers.*', 'master_account_codes.account_code', 'master_account_codes.account_name')
             ->leftjoin('master_account_codes', 'general_ledgers.id_account_code', 'master_account_codes.id')
@@ -432,7 +484,7 @@ class TransPurchaseController extends Controller
     {
         // dd($request->all());
         $request->validate([
-            'date_invoice'              => 'required',
+            'date_invoice'              => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
             'invoice_number'            => 'required',
             'tax_invoice_number'        => 'required',
             'ppn_rate'                  => 'required',
@@ -445,6 +497,7 @@ class TransPurchaseController extends Controller
         $detail    = TransPurchase::where('id', $id)->lockForUpdate()->first();
         $requestLP = json_decode($request->listProduct, true);
         $disc      = $this->normalizePrice($request->discount);
+        $disc      = $this->coretaxRound($disc);
         $invNumber = $request->invoice_number;
 
         // Validation
@@ -588,11 +641,10 @@ class TransPurchaseController extends Controller
             $id = decrypt($id);
             $detail  = TransPurchase::findOrFail($id);
 
-            // Validation
-            $trxDate = Carbon::parse($detail->date_invoice);
-            $now     = Carbon::now();
-            if (!$trxDate->isSameMonth($now)) {
-                return back()->with('error', 'This transaction cannot be deleted because the transaction month has already passed.');
+            if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+                return redirect()->route('transpurchase.index')->with([
+                    'fail' => 'Transactions can only be deleted within 20 days prior to the current date.'
+                ]);
             }
 
             $lastStatusGRN = $detail->last_status_grn ?? 'Posted';

--- a/app/Http/Controllers/TransSalesController.php
+++ b/app/Http/Controllers/TransSalesController.php
@@ -143,138 +143,192 @@ class TransSalesController extends Controller
     }
     public function getSOPriceFromDN(Request $request)
     {
-        $idDN       = $request->idDN;
-        $ppnRate    = $request->ppnRate;
+        $idDN    = $request->idDN;
+        $ppnRate = $request->ppnRate;
+        $rule    = $request->rule;
+
+        $isCoretax = ($rule === "Coretax");
+
+        // Coretax rounding helper (SQL)
+        $coretax = function ($expression) use ($isCoretax) {
+            if (!$isCoretax) {
+                return "ROUND($expression, 3)";
+            }
+
+            return "
+                CASE 
+                    WHEN (($expression) - FLOOR(($expression))) >= 0.5 
+                        THEN CEIL(($expression))
+                    ELSE FLOOR(($expression))
+                END
+            ";
+        };
 
         $datas = DeliveryNoteDetail::select(
-                'sales_orders.id as id_sales_orders',
-                'sales_orders.so_number',
-                'sales_orders.type_product',
-                DB::raw("
+            'sales_orders.id as id_sales_orders',
+            'sales_orders.so_number',
+            'sales_orders.type_product',
+            DB::raw("
+                CASE 
+                    WHEN sales_orders.type_product = 'RM' THEN master_raw_materials.description
+                    WHEN sales_orders.type_product = 'WIP' THEN master_wips.description
+                    WHEN sales_orders.type_product = 'FG' THEN master_product_fgs.description
+                    WHEN sales_orders.type_product IN ('TA', 'Other') THEN master_tool_auxiliaries.description
+                END as product
+            "),
+            'sales_orders.qty',
+            'master_units.unit as unit',
+            'sales_orders.ppn as ppn_type',
+
+            DB::raw("
+                {$coretax("sales_orders.price")}
+                as price_origin
+            "),
+            DB::raw("
+                {$coretax("sales_orders.total_price")}
+                as total_price_origin
+            "),
+
+            DB::raw("$ppnRate as ppn_rate"),
+
+            // =========================
+            // PPN VALUE
+            // =========================
+            DB::raw("
+                {$coretax("
                     CASE 
-                        WHEN sales_orders.type_product = 'RM' THEN master_raw_materials.description
-                        WHEN sales_orders.type_product = 'WIP' THEN master_wips.description
-                        WHEN sales_orders.type_product = 'FG' THEN master_product_fgs.description
-                        WHEN sales_orders.type_product IN ('TA', 'Other') THEN master_tool_auxiliaries.description
-                    END as product
-                "),
-                'sales_orders.qty',
-                'master_units.unit as unit',
-                'sales_orders.ppn as ppn_type',
-                'sales_orders.price as price_origin',
-                'sales_orders.total_price as total_price_origin',
-                DB::raw("$ppnRate as ppn_rate"),
+                        WHEN sales_orders.ppn = 'Exclude' 
+                            THEN ({$coretax("sales_orders.price")} * $ppnRate / 100)
+                        WHEN sales_orders.ppn = 'Include' 
+                            THEN ({$coretax("sales_orders.price")} - ({$coretax("sales_orders.price")} / (1 + ($ppnRate / 100))))
+                        ELSE 0
+                    END
+                ")} as ppn_value
+            "),
 
-                // PPN value
-                DB::raw("
-                    ROUND(
-                        CASE 
-                            WHEN sales_orders.ppn = 'Exclude' 
-                                THEN (sales_orders.price * $ppnRate / 100)
-                            WHEN sales_orders.ppn = 'Include' 
-                                THEN (sales_orders.price - (sales_orders.price / (1 + ($ppnRate / 100))))
-                            ELSE 0
-                        END
-                    , 3) as ppn_value
-                "),
-                // Price before PPN (for Include)
-                DB::raw("
-                    ROUND(
-                        CASE 
-                            WHEN sales_orders.ppn = 'Include' 
-                                THEN (sales_orders.price / (1 + ($ppnRate / 100)))
-                            ELSE sales_orders.price
-                        END
-                    , 3) as price_before_ppn
-                "),
-                // Total price before PPN (for Include)
-                DB::raw("
-                    ROUND(
-                        CASE 
-                            WHEN sales_orders.ppn = 'Include' 
-                                THEN (sales_orders.total_price / (1 + ($ppnRate / 100)))
-                            ELSE sales_orders.total_price
-                        END
-                    , 3) as total_price_before_ppn
-                "),
-                // Price after PPN (for Exclude)
-                DB::raw("
-                    ROUND(
-                        CASE 
-                            WHEN sales_orders.ppn = 'Exclude' 
-                                THEN (sales_orders.price * (1 + ($ppnRate / 100)))
-                            ELSE sales_orders.price
-                        END
-                    , 3) as price_after_ppn
-                "),
-                // Total price after PPN (for Exclude)
-                DB::raw("
-                    ROUND(
-                        CASE 
-                            WHEN sales_orders.ppn = 'Exclude' 
-                                THEN (sales_orders.total_price * (1 + ($ppnRate / 100)))
-                            ELSE sales_orders.total_price
-                        END
-                    , 3) as total_price_after_ppn
-                ")
-            )
-            ->leftJoin('sales_orders', 'delivery_note_details.id_sales_orders', 'sales_orders.id')
-            ->leftJoin('master_raw_materials', function ($join) {
-                $join->on('sales_orders.id_master_products', '=', 'master_raw_materials.id')
-                    ->where('sales_orders.type_product', '=', 'RM');
-            })
-            ->leftJoin('master_wips', function ($join) {
-                $join->on('sales_orders.id_master_products', '=', 'master_wips.id')
-                    ->where('sales_orders.type_product', '=', 'WIP');
-            })
-            ->leftJoin('master_product_fgs', function ($join) {
-                $join->on('sales_orders.id_master_products', '=', 'master_product_fgs.id')
-                    ->where('sales_orders.type_product', '=', 'FG');
-            })
-            ->leftJoin('master_tool_auxiliaries', function ($join) {
-                $join->on('sales_orders.id_master_products', '=', 'master_tool_auxiliaries.id')
-                    ->whereIn('sales_orders.type_product', ['TA', 'Other']);
-            })
-            ->leftJoin('master_units', 'sales_orders.id_master_units', 'master_units.id')
-            ->where('delivery_note_details.id_delivery_notes', $idDN)
-            ->get();
+            // =========================
+            // PRICE BEFORE PPN
+            // =========================
+            DB::raw("
+                {$coretax("
+                    CASE 
+                        WHEN sales_orders.ppn = 'Include' 
+                            THEN ({$coretax("sales_orders.price")} / (1 + ($ppnRate / 100)))
+                        ELSE {$coretax("sales_orders.price")}
+                    END
+                ")} as price_before_ppn
+            "),
 
-        $ppnType       = $datas->first() ? $datas->first()->ppn_type : null;
-        $totalPrice     = (float) $datas->sum('total_price_before_ppn');
-        $dppFactor      = (float) 11/12;
-        $dppValue       = (float) ($totalPrice) * $dppFactor;
-        $ppnValue       = (float) ($ppnRate/100) * $totalPrice;
-        $total          = (float) $totalPrice + $ppnValue;
-        
+            // =========================
+            // TOTAL PRICE BEFORE PPN
+            // =========================
+            DB::raw("
+                {$coretax("
+                    CASE 
+                        WHEN sales_orders.ppn = 'Include' 
+                            THEN ({$coretax("sales_orders.total_price")} / (1 + ($ppnRate / 100)))
+                        ELSE {$coretax("sales_orders.total_price")}
+                    END
+                ")} as total_price_before_ppn
+            "),
+
+            // =========================
+            // PRICE AFTER PPN
+            // =========================
+            DB::raw("
+                {$coretax("
+                    CASE 
+                        WHEN sales_orders.ppn = 'Exclude' 
+                            THEN ({$coretax("sales_orders.price")} * (1 + ($ppnRate / 100)))
+                        ELSE {$coretax("sales_orders.price")}
+                    END
+                ")} as price_after_ppn
+            "),
+
+            // =========================
+            // TOTAL AFTER PPN
+            // =========================
+            DB::raw("
+                {$coretax("
+                    CASE 
+                        WHEN sales_orders.ppn = 'Exclude' 
+                            THEN ({$coretax("sales_orders.total_price")} * (1 + ($ppnRate / 100)))
+                        ELSE {$coretax("sales_orders.total_price")}
+                    END
+                ")} as total_price_after_ppn
+            ")
+        )
+
+        ->leftJoin('sales_orders', 'delivery_note_details.id_sales_orders', 'sales_orders.id')
+        ->leftJoin('master_raw_materials', function ($join) {
+            $join->on('sales_orders.id_master_products', '=', 'master_raw_materials.id')
+                ->where('sales_orders.type_product', '=', 'RM');
+        })
+        ->leftJoin('master_wips', function ($join) {
+            $join->on('sales_orders.id_master_products', '=', 'master_wips.id')
+                ->where('sales_orders.type_product', '=', 'WIP');
+        })
+        ->leftJoin('master_product_fgs', function ($join) {
+            $join->on('sales_orders.id_master_products', '=', 'master_product_fgs.id')
+                ->where('sales_orders.type_product', '=', 'FG');
+        })
+        ->leftJoin('master_tool_auxiliaries', function ($join) {
+            $join->on('sales_orders.id_master_products', '=', 'master_tool_auxiliaries.id')
+                ->whereIn('sales_orders.type_product', ['TA', 'Other']);
+        })
+        ->leftJoin('master_units', 'sales_orders.id_master_units', 'master_units.id')
+        ->where('delivery_note_details.id_delivery_notes', $idDN)
+        ->get();
+
+        // =========================
+        // SUMMARY CALCULATION
+        // =========================
+        $ppnType    = $datas->first() ? $datas->first()->ppn_type : null;
+        $totalPrice = (float) $datas->sum('total_price_before_ppn');
+        $dppFactor  = 11 / 12;
+        $dppValue   = $totalPrice * $dppFactor;
+        $ppnValue   = ($ppnRate / 100) * $totalPrice;
+        $total      = $totalPrice + $ppnValue;
+
+        // Coretax rounding for summary
+        if ($isCoretax) {
+            $totalPrice = $this->coretaxRound($totalPrice);
+            $dppValue = $this->coretaxRound($dppValue);
+            $ppnValue = $this->coretaxRound($ppnValue);
+            $total    = $this->coretaxRound($total);
+        }
+
         if ($request->ajax()) {
             return DataTables::of($datas)
                 ->with([
-                    'nj'        => $totalPrice,
-                    'dpp'       => $dppValue,
-                    'ppn_rate'  => $ppnRate,
-                    'ppn'       => $ppnValue,
-                    'total'     => $total,
+                    'nj'       => $totalPrice,
+                    'dpp'      => $dppValue,
+                    'ppn_rate' => $ppnRate,
+                    'ppn'      => $ppnValue,
+                    'total'    => $total,
                 ])
                 ->toJson();
         }
-        
-        $response = [
-            'datas'     => $datas,
-            'ppnType'   => $ppnType,
-            'nj'        => $totalPrice,
-            'dpp'       => $dppValue,
-            'ppn_rate'  => $ppnRate,
-            'ppn'       => $ppnValue,
-            'total'     => $total,
+
+        return [
+            'datas'    => $datas,
+            'ppnType'  => $ppnType,
+            'nj'       => $totalPrice,
+            'dpp'      => $dppValue,
+            'ppn_rate' => $ppnRate,
+            'ppn'      => $ppnValue,
+            'total'    => $total,
         ];
-        return $response;
     }
 
-    function generateRefNumber($noUrutDN)
+    function generateRefNumber($noUrutDN, $dateInvoice = null)
     {
-        // Get current year and month
-        $year = date('y');
-        $month = date('m');
+        // Use invoice date if provided, otherwise use current date
+        $date = $dateInvoice ? strtotime($dateInvoice) : time();
+
+        $year = date('y', $date);
+        $month = date('m', $date);
+
         // Convert the numeric month to a Roman numeral
         $romanMonths = [
             '01' => 'I',
@@ -381,8 +435,14 @@ class TransSalesController extends Controller
                 $datas = $datas->whereDate('trans_sales.created_at','>=',$startdate)->whereDate('trans_sales.created_at','<=',$enddate);
             }
             
-            if($request->flag){
-                $datas = $datas->get()->makeHidden(['id']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             $datas = $datas->get();
@@ -452,8 +512,14 @@ class TransSalesController extends Controller
                 $datas = $datas->whereDate('trans_sales_export.created_at','>=',$startdate)->whereDate('trans_sales_export.created_at','<=',$enddate);
             }
             
-            if($request->flag){
-                $datas = $datas->get()->makeHidden(['id']);
+            if ($request->flag != null) {
+                $datas = $datas->get()->map(function ($item) {
+                    $data = $item->toArray();
+                    unset($data['id'], $data['created_at'], $data['updated_at']);
+                    $data['created_at'] = $item->created_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    $data['updated_at'] = $item->updated_at->timezone('Asia/Jakarta')->format('Y-m-d H:i:s');
+                    return $data;
+                });
                 return $datas;
             }
             $datas = $datas->get();
@@ -513,8 +579,8 @@ class TransSalesController extends Controller
     {
         // dd($request->all());
         $request->validate([
-            'date_invoice'              => 'required',
-            'due_date'                  => 'required|date|after_or_equal:today',
+            'date_invoice'              => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
+            'due_date'                  => 'required|date|after_or_equal:date_invoice',
             'id_delivery_notes'         => 'required',
             'dn_number'                 => 'required',
             'dn_date'                   => 'required',
@@ -540,10 +606,14 @@ class TransSalesController extends Controller
         $detailSOnPrice = $this->getSOPriceFromDN(new Request([
             'idDN'    => $idDN,
             'ppnRate' => $ppnRate,
+            'rule'    => "Coretax",
         ]));
         $detailSO = $detailSOnPrice ? $detailSOnPrice['datas'] : collect();
         // Generate Ref Number
-        $refNumber = $this->generateRefNumber(substr($request->dn_number ?? '000000', -6));
+        $refNumber = $this->generateRefNumber(
+            substr($request->dn_number ?? '000000', -6),
+            $request->date_invoice ?? null
+        );
     
         DB::beginTransaction();
         try{
@@ -760,6 +830,12 @@ class TransSalesController extends Controller
     {
         $idTS = decrypt($id);
         $detail = TransSales::where('id', $idTS)->first();
+        if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+            return redirect()->route('transsales.local.index')->with([
+                'fail' => 'Transactions can only be edited within 20 days prior to the current date.'
+            ]);
+        }
+
         $detailCust = $this->getCustomerFromDN($detail->id_delivery_notes);
         $detailTransSales = TransSalesDetailPrice::where('id_trans_sales_parent', $idTS)->where('type_sales', 'Local')->get();
         $generalLedgers = GeneralLedger::select('general_ledgers.*', 'master_account_codes.account_code', 'master_account_codes.account_name')
@@ -818,8 +894,8 @@ class TransSalesController extends Controller
     public function updateLocal(Request $request, $id)
     {
         $request->validate([
-            'date_invoice'              => 'required',
-            'due_date'                  => 'required|date',
+            'date_invoice'              => 'required|date|after_or_equal:' . date('Y-m-d', strtotime('-20 days')) . '|before_or_equal:today',
+            'due_date'                  => 'required|date|after_or_equal:date_invoice',
             'id_master_bank_account'    => 'required',
             'ppn_rate'                  => 'required',
             'addmore.*.account_code'    => 'required',
@@ -829,13 +905,6 @@ class TransSalesController extends Controller
         
         $idTS = decrypt($id);
         $detail = TransSales::where('id', $idTS)->lockForUpdate()->first();
-
-        // Validation
-        $trxDate = Carbon::parse($detail->date_invoice);
-        $now     = Carbon::now();
-        if (!$trxDate->isSameMonth($now)) {
-            return back()->with('error', 'This transaction cannot be updated because the transaction month has already passed.');
-        }
         
         $detail->date_invoice = $request->date_invoice . ' 00:00:00';
         $detail->due_date     = $request->due_date . ' 00:00:00';
@@ -866,9 +935,25 @@ class TransSalesController extends Controller
         if($isChangedDetail || $isChangedPPNRate || $isChangedTransaction) {
             DB::beginTransaction();
             try{
+                // Init Default refNumber
+                $refNumber = $detail->ref_number;
+
                 if($isChangedDetail) {
+                    // Re-Generate Ref Number
+                    $refNumber = $this->generateRefNumber(
+                        substr($detail->dn_number ?? '000000', -6),
+                        $request->date_invoice ?? null
+                    );
+
+                    if ($detail->ref_number != $refNumber) {
+                        GeneralLedger::where('id_ref', $idTS)->where('ref_number', $detail->ref_number)->where('source', 'Sales (Local)')->update([
+                            'ref_number' => $refNumber
+                        ]);
+                    }
+                    
                     $bankAccount = MstBankAccount::where('id', $request->id_master_bank_account)->first();
                     TransSales::where('id', $idTS)->update([
+                        'ref_number'   => $refNumber,
                         'date_invoice' => $request->date_invoice,
                         'due_date'     => $request->due_date,
                         'id_master_bank_account' => $request->id_master_bank_account,
@@ -887,6 +972,7 @@ class TransSalesController extends Controller
                     $detailSOnPrice = $this->getSOPriceFromDN(new Request([
                         'idDN'    => $detail->id_delivery_notes,
                         'ppnRate' => $request->ppn_rate,
+                        'rule'    => "Coretax",
                     ]));
                     $detailSO = $detailSOnPrice ? $detailSOnPrice['datas'] : collect();
                     // Update Total Price
@@ -934,7 +1020,7 @@ class TransSalesController extends Controller
                         $this->updateBalanceAccount($item['account_code'], $nominal, $reverseType);
                     }
                     // Delete General Ledger
-                    GeneralLedger::where('id_ref', $idTS)->where('ref_number', $detail->ref_number)->where('source', 'Sales (Local)')->delete();
+                    GeneralLedger::where('id_ref', $idTS)->where('ref_number', $refNumber)->where('source', 'Sales (Local)')->delete();
 
                     // Insert New
                     foreach($request->addmore as $item){
@@ -942,7 +1028,7 @@ class TransSalesController extends Controller
                             $nominal = $this->normalizeOpeningBalance($item['nominal']);
                             // Create General Ledger
                             $this->storeGeneralLedger(
-                                $idTS, $detail->ref_number, $request->date_invoice, 
+                                $idTS, $refNumber, $request->date_invoice, 
                                 $item['account_code'], $item['type'], $nominal, $item['note'], 
                                 'Sales (Local)', $request->dn_number);
                             // Update & Calculate Balance Account Code
@@ -982,7 +1068,7 @@ class TransSalesController extends Controller
         $trxDate = Carbon::parse($detail->date_invoice);
         $now     = Carbon::now();
         if (!$trxDate->isSameMonth($now)) {
-            return back()->with('error', 'This transaction cannot be updated because the transaction month has already passed.');
+            return back()->with('fail', 'This transaction cannot be updated because the transaction month has already passed.');
         }
         
         $requestApp = json_encode([
@@ -1129,12 +1215,11 @@ class TransSalesController extends Controller
             $idTS = decrypt($id);
 
             $detail  = TransSales::findOrFail($idTS);
-
-            // Validation
-            $trxDate = Carbon::parse($detail->date_invoice);
-            $now     = Carbon::now();
-            if (!$trxDate->isSameMonth($now)) {
-                return back()->with('error', 'This transaction cannot be deleted because the transaction month has already passed.');
+            
+            if (\Carbon\Carbon::parse($detail->date_invoice)->lt(\Carbon\Carbon::today()->subDays(20))) {
+                return redirect()->route('transsales.local.index')->with([
+                    'fail' => 'Transactions can only be deleted within 20 days prior to the current date.'
+                ]);
             }
 
             DeliveryNote::where('id', $detail->id_delivery_notes)->update(['status' => 'Posted']);

--- a/app/Traits/GeneralLedgerTrait.php
+++ b/app/Traits/GeneralLedgerTrait.php
@@ -185,4 +185,12 @@ trait GeneralLedgerTrait {
             'Bukti Bank Masuk',
         ];
     }
+
+    public function coretaxRound($value)
+    {
+        $int = floor($value);
+        $decimal = $value - $int;
+
+        return ($decimal >= 0.5) ? ceil($value) : floor($value);
+    }
 }

--- a/public/assets/js/currencyFormat.js
+++ b/public/assets/js/currencyFormat.js
@@ -16,6 +16,23 @@ $(document).on("input", ".currency-input", function () {
     formatCurrencyInput({ target: this });
 });
 
+// Format Rupiah without comma/decimal
+function formatCurrencyInputNoComma(event) {
+    let value = event.target.value;
+
+    // remove all non-digit characters
+    value = value.replace(/\D/g, "");
+
+    // add thousand separator
+    value = value.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+    event.target.value = value;
+}
+$(document).on("input", ".currency-input-no-comma", function () {
+    formatCurrencyInputNoComma({ target: this });
+});
+
+
 
 function formatPrice(value) {
     if (!value) return '0';
@@ -39,4 +56,15 @@ function formatPriceWithStyle(value) {
     let before = parts[0]; // integer part with thousand separator
     let after = parts[1] ? ',' + parts[1] : '';
     return `<span class="fw-bold">${before}</span><span class="text-muted">${after}</span>`;
+}
+function formatPriceWithStyleCoretax(value) {
+    // Format with 3 decimals, comma as decimal sep, dot as thousand sep
+    let formatted = new Intl.NumberFormat('de-DE', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    }).format(value);
+    // Split integer and decimal part
+    let parts = formatted.split(',');
+    let before = parts[0]; // integer part with thousand separator
+    return `<span class="fw-bold">${before}</span>`;
 }

--- a/public/assets/js/custom.js
+++ b/public/assets/js/custom.js
@@ -34,6 +34,25 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 });
 
+// Format Rupiah without comma/decimal
+function formatCurrencyInputNoComma(event) {
+    let value = event.target.value;
+
+    // remove all non-digit characters
+    value = value.replace(/\D/g, "");
+
+    // add thousand separator
+    value = value.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+    event.target.value = value;
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+        input.addEventListener("input", formatCurrencyInputNoComma);
+    });
+});
+
 function numberFormat(number, decimals, decPoint, thousandsSep) {
     // Fix for NaN cases
     if (!isFinite(number)) {

--- a/public/assets/js/helperDT.js
+++ b/public/assets/js/helperDT.js
@@ -6,6 +6,15 @@ function formatAmountDT(amount) {
         ? `<span class="text-bold">${whole}</span><span class="text-muted">,${decimal}</span>`
         : `<span class="text-bold">${whole}</span>`;
 }
+// Helper: format number using Coretax rule (rounded to whole Rupiah)
+function formatAmountDTCoretax(amount) {
+    // Coretax rounding
+    const rounded = Math.round(parseFloat(amount) || 0);
+    // Format: 1.234.567
+    const formatted = numberFormat(rounded, 0, ',', '.');
+    return `<span class="text-bold">${formatted}</span>`;
+}
+
 // Helper: badge builder
 function badgeDT(color, text, icon = '') {
     return `<span class="badge bg-${color} text-white">${icon ? `<span class="mdi ${icon}"></span> | ` : ''}${text}</span>`;

--- a/resources/views/cashbook/action.blade.php
+++ b/resources/views/cashbook/action.blade.php
@@ -1,6 +1,6 @@
 @php
     use Carbon\Carbon;
-    $isCurrentMonth = Carbon::parse($data->date_invoice)->isSameMonth(now());
+    $canModify = Carbon::parse($data->date_invoice)->greaterThanOrEqualTo(Carbon::today()->subDays(20));
 @endphp
 
 <div class="btn-group">
@@ -16,7 +16,7 @@
         <span>Info</span>
     </a>
     @can('Akunting_master_data')
-        @if($isCurrentMonth)
+        @if($canModify)
             <hr class="m-0">
             <a href="{{ route('cashbook.edit', encrypt($data->id)) }}" class="dropdown-item-floating d-flex align-items-center gap-2">
                 <i class="mdi mdi-file-edit"></i>

--- a/resources/views/cashbook/create.blade.php
+++ b/resources/views/cashbook/create.blade.php
@@ -40,9 +40,14 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Pilih tanggal invoice. Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ date('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ date('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                             </div>
                             <div class="row">
@@ -98,7 +103,7 @@
                                         </div>
                                         <div class="card-body">
                                             <!-- Transaction Note -->
-                                            <div class="alert alert-info small mb-3">
+                                            <div class="alert alert-info small mb-2">
                                                 <strong>Note:</strong><br>
                                                 Pada bagian <b>Index</b> dan <b>Print Invoice</b>, akun yang ditampilkan adalah:
                                                 <ul class="mb-0 ps-3">
@@ -106,6 +111,15 @@
                                                     <li><b>Bukti Kas Keluar & Bank Keluar</b> → List akun <b>Debit</b> saja</li>
                                                 </ul>
                                             </div>
+
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block mb-3" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+
                                             <div class="table-repsonsive">
                                                 <table class="table table-bordered" id="dynamicTable">
                                                     <thead>
@@ -128,7 +142,7 @@
                                                                 </select>
                                                             </td>
                                                             <td>
-                                                                <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
+                                                                <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
                                                             </td>
                                                             <td>
                                                                 <select class="form-select select2 addpayment" style="width: 100%" name="addmore[0][type]" required>
@@ -310,7 +324,7 @@
                     </select>
                 </td>
                 <td>
-                    <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
+                    <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
                 </td>
                 <td>
                     <select class="form-select select2 addpayment" style="width: 100%" name="addmore[`+i+`][type]" required>
@@ -329,8 +343,8 @@
 
         $(".select2").select2();
 
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     });
     $(document).on('click', '.remove-tr', function() {

--- a/resources/views/cashbook/edit.blade.php
+++ b/resources/views/cashbook/edit.blade.php
@@ -40,9 +40,14 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Pilih tanggal invoice. Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                             </div>
                             <div class="row">
@@ -95,6 +100,15 @@
                                                     <li><b>Bukti Kas Keluar & Bank Keluar</b> → List akun <b>Debit</b> saja</li>
                                                 </ul>
                                             </div>
+                                            
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block mb-3" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+
                                             <div class="table-responsive">
                                                 <table class="table table-bordered" id="dynamicTable">
                                                     <thead>
@@ -122,9 +136,9 @@
                                                             </td>
                                                             <td>
                                                                 <input type="text"
-                                                                    class="form-control rupiah-input addpayment"
+                                                                    class="form-control rupiah-input-no-comma addpayment"
                                                                     name="addmore[{{ $index }}][nominal]"
-                                                                    value="{{ number_format($ledger->amount, 2, ',', '.') }}"
+                                                                    value="{{ number_format($ledger->amount, 0, ',', '.') }}"
                                                                     required>
                                                             </td>
                                                             <td>
@@ -281,9 +295,9 @@
 
     function initPlugins() {
         $('.select2').select2({ width: '100%' });
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.removeEventListener("input", formatCurrencyInput);
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.removeEventListener("input", formatCurrencyInputNoComma);
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     }
 
@@ -310,7 +324,7 @@
             </td>
             <td>
                 <input type="text"
-                    class="form-control rupiah-input addpayment"
+                    class="form-control rupiah-input-no-comma addpayment"
                     name="addmore[${i}][nominal]"
                     placeholder="Input Amount.." required>
             </td>
@@ -344,12 +358,6 @@
     $(document).on('click', '.remove-tr', function () {
         $(this).closest('tr').remove();
     });
-
-    // RUPIAH FORMATTER
-    function formatCurrencyInput(e) {
-        let value = e.target.value.replace(/\D/g, '');
-        e.target.value = value.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-    }
 </script>
 
 @endsection

--- a/resources/views/cashbook/index.blade.php
+++ b/resources/views/cashbook/index.blade.php
@@ -125,10 +125,10 @@
                                 </div>
                             </div>
                             <div class="col-lg-4">
-                                <div class="alert alert-warning mb-0 small d-none d-lg-block" role="alert">
+                                <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
                                     <ul class="mb-0 ps-3">
                                         <li>
-                                            <b>Edit</b> & <b>Delete</b> actions are only available for <b>Super Admin</b> and only for transactions within the <b>current month.</b>
+                                            <b>Super Admin</b> can <b>Edit</b> & <b>Delete</b> transactions within <b>20 days</b> only.
                                         </li>
                                     </ul>
                                 </div>
@@ -242,7 +242,7 @@
             data: 'amount',
             orderable: true,
             className: 'align-top text-end',
-            render: (data, type, row) => formatAmountDT(data),
+            render: (data, type, row) => formatAmountDTCoretax(data),
         },
         {
             data: 'transaction',

--- a/resources/views/cashbook/modal/info.blade.php
+++ b/resources/views/cashbook/modal/info.blade.php
@@ -64,11 +64,12 @@
                                 {{ $item->account_code." - ".$item->account_name }}
                             </td>
                             <td class="text-end">
-                                @php
+                                {{-- @php
                                     $formatted = number_format($item->amount, 2, ',', '.');
                                     [$before, $after] = explode(',', $formatted);
                                 @endphp
-                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                <span class="fw-bold">{{ number_format(round($item->amount), 0, ',', '.') }}</span>
                             </td>
                             <td class="text-center">
                                 @if($item->transaction == 'D')

--- a/resources/views/pdf/cashbookBBK.blade.php
+++ b/resources/views/pdf/cashbookBBK.blade.php
@@ -120,7 +120,10 @@
                                 ">
                             {{ $item->note ?? '-' }}
                         </td>
-                        <td class="px-2 text-right" style="border-right: 0.75px solid black">{{ number_format($item->amount, 2, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-right: 0.75px solid black">
+                            {{-- {{ number_format($item->amount, 2, ',', '.') }} --}}
+                            {{ number_format(round($item->amount), 0, ',', '.') }}
+                        </td>
                     </tr>
                 @endforeach
                 <tr>
@@ -134,7 +137,8 @@
                     <td class="text-right px-2" style="vertical-align: top;">TERBILANG : </td>
                     <td class="px-2" style="text-decoration: underline; vertical-align: top;">{{ strtoupper($terbilangString ?? '-') }}</td>
                     <td class="px-2 text-right" style="vertical-align: top; border-bottom: 0.75px solid; border-left: 0.75px solid; border-right: 0.75px solid black;">
-                        {{ number_format($detail->total, 2, ',', '.') }}
+                        {{-- {{ number_format($detail->total, 2, ',', '.') }} --}}
+                        {{ number_format(round($detail->total), 0, ',', '.') }}
                     </td>
                 </tr>
             </tfoot>

--- a/resources/views/pdf/cashbookBBM.blade.php
+++ b/resources/views/pdf/cashbookBBM.blade.php
@@ -120,7 +120,10 @@
                                 ">
                             {{ $item->note ?? '-' }}
                         </td>
-                        <td class="px-2 text-right" style="border-right: 0.75px solid black">{{ number_format($item->amount, 2, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-right: 0.75px solid black">
+                            {{-- {{ number_format($item->amount, 2, ',', '.') }} --}}
+                            {{ number_format(round($item->amount), 0, ',', '.') }}
+                        </td>
                     </tr>
                 @endforeach
                 <tr>
@@ -134,7 +137,8 @@
                     <td class="text-right px-2" style="vertical-align: top;">TERBILANG : </td>
                     <td class="px-2" style="text-decoration: underline; vertical-align: top;">{{ strtoupper($terbilangString ?? '-') }}</td>
                     <td class="px-2 text-right" style="vertical-align: top; border-bottom: 0.75px solid; border-left: 0.75px solid; border-right: 0.75px solid black;">
-                        {{ number_format($detail->total, 2, ',', '.') }}
+                        {{-- {{ number_format($detail->total, 2, ',', '.') }} --}}
+                        {{ number_format(round($detail->total), 0, ',', '.') }}
                     </td>
                 </tr>
             </tfoot>

--- a/resources/views/pdf/cashbookBKK.blade.php
+++ b/resources/views/pdf/cashbookBKK.blade.php
@@ -120,7 +120,10 @@
                                 ">
                             {{ $item->note ?? '-' }}
                         </td>
-                        <td class="px-2 text-right" style="border-right: 0.75px solid black">{{ number_format($item->amount, 2, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-right: 0.75px solid black">
+                            {{-- {{ number_format($item->amount, 2, ',', '.') }} --}}
+                            {{ number_format(round($item->amount), 0, ',', '.') }}
+                        </td>
                     </tr>
                 @endforeach
                 <tr>
@@ -134,7 +137,8 @@
                     <td class="text-right px-2">TERBILANG : </td>
                     <td class="px-2" style="text-decoration: underline;">{{ strtoupper($terbilangString ?? '-') }}</td>
                     <td class="px-2 text-right" style="border-bottom: 0.75px solid; border-left: 0.75px solid; border-right: 0.75px solid black">
-                        {{ number_format($detail->total, 2, ',', '.') }}
+                        {{-- {{ number_format($detail->total, 2, ',', '.') }} --}}
+                        {{ number_format(round($detail->total), 0, ',', '.') }}
                     </td>
                 </tr>
             </tfoot>

--- a/resources/views/pdf/cashbookBKM.blade.php
+++ b/resources/views/pdf/cashbookBKM.blade.php
@@ -120,7 +120,10 @@
                                 ">
                             {{ $item->note ?? '-' }}
                         </td>
-                        <td class="px-2 text-right" style="border-right: 0.75px solid black">{{ number_format($item->amount, 2, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-right: 0.75px solid black">
+                            {{-- {{ number_format($item->amount, 2, ',', '.') }} --}}
+                            {{ number_format(round($item->amount), 0, ',', '.') }}
+                        </td>
                     </tr>
                 @endforeach
                 <tr>
@@ -134,7 +137,8 @@
                     <td class="text-right px-2">TERBILANG : </td>
                     <td class="px-2" style="text-decoration: underline;">{{ strtoupper($terbilangString ?? '-') }}</td>
                     <td class="px-2 text-right" style="border-bottom: 0.75px solid; border-left: 0.75px solid; border-right: 0.75px solid black">
-                        {{ number_format($detail->total, 2, ',', '.') }}
+                        {{-- {{ number_format($detail->total, 2, ',', '.') }} --}}
+                        {{ number_format(round($detail->total), 0, ',', '.') }}
                     </td>
                 </tr>
             </tfoot>

--- a/resources/views/pdf/transsaleslocal.blade.php
+++ b/resources/views/pdf/transsaleslocal.blade.php
@@ -145,19 +145,8 @@
                                 : number_format(floor($item->qty), 0, ',', '.') . ',' . rtrim(str_replace('.', '', explode('.', (string)$item->qty)[1]), '0') }}
                             {{ ' '. $item->unit }}
                         </td>
-                        <td class="px-2 text-right" style="border-bottom: none; border-top: none;">{{ number_format($item->price_before_ppn, 2, ',', '.') }}</td>
-                        <td class="px-2 text-right" style="border-right: none; border-bottom: none; border-top: none;">{{ number_format($item->total_price_before_ppn, 2, ',', '.') }}</td>
-                    </tr>
-                    <tr>
-                        <td class="px-2" style="border-left: none; border-bottom: none; border-top: none;">{{ $item->product }}</td>
-                        <td class="px-2 text-center" style="border-bottom: none; border-top: none;">
-                            {{ fmod($item->qty, 1) == 0 
-                                ? number_format($item->qty, 0, ',', '.') 
-                                : number_format(floor($item->qty), 0, ',', '.') . ',' . rtrim(str_replace('.', '', explode('.', (string)$item->qty)[1]), '0') }}
-                            {{ ' '. $item->unit }}
-                        </td>
-                        <td class="px-2 text-right" style="border-bottom: none; border-top: none;">{{ number_format($item->price_before_ppn, 2, ',', '.') }}</td>
-                        <td class="px-2 text-right" style="border-right: none; border-bottom: none; border-top: none;">{{ number_format($item->total_price_before_ppn, 2, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-bottom: none; border-top: none;">{{ number_format(round($item->price_before_ppn), 0, ',', '.') }}</td>
+                        <td class="px-2 text-right" style="border-right: none; border-bottom: none; border-top: none;">{{ number_format(round($item->total_price_before_ppn), 0, ',', '.') }}</td>
                     </tr>
                 @endforeach
                 <tr>
@@ -221,25 +210,25 @@
                         <tr style="font-size: 10px;">
                             <td class="align-top" style="width:50%;">Nilai Jual</td>
                             <td class="text-right align-top" style="width:50%;">
-                                <b>{{ number_format($detail->sales_value, 2, ',', '.') }}</b>
+                                <b>{{ number_format(round($detail->sales_value), 0, ',', '.') }}</b>
                             </td>
                         </tr>
                         <tr style="font-size: 10px;">
                             <td class="align-top" style="width:50%;">DPP Lain-lain</td>
                             <td class="text-right align-top" style="width:50%;">
-                                <b>{{ number_format($detail->dpp, 2, ',', '.') }}</b>
+                                <b>{{ number_format(round($detail->dpp), 0, ',', '.') }}</b>
                             </td>
                         </tr>
                         <tr style="font-size: 10px;">
                             <td class="align-top" style="width:50%;">PPN</td>
                             <td class="text-right align-top" style="width:50%;">
-                                <b>{{ number_format($detail->ppn_value, 2, ',', '.') }}</b>
+                                <b>{{ number_format(round($detail->ppn_value), 0, ',', '.') }}</b>
                             </td>
                         </tr>
                         <tr style="font-size: 10px;">
                             <td class="align-top" style="width:50%;">Total Nilai Jual + PPN</td>
                             <td class="text-right align-top" style="width:50%;">
-                                <b>{{ number_format($detail->total, 2, ',', '.') }}</b>
+                                <b>{{ number_format(round($detail->total), 0, ',', '.') }}</b>
                             </td>
                         </tr>
                     </table>

--- a/resources/views/report/monthly/index.blade.php
+++ b/resources/views/report/monthly/index.blade.php
@@ -76,7 +76,7 @@
                                 <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.6rem;" role="alert">
                                     <ul class="mb-0 ps-3">
                                         <li>
-                                            Transactions made after the sync time on month-end will be included in the next month’s report.
+                                            Sync report will recalculate transactions for the last two months.
                                         </li>
                                     </ul>
                                 </div>
@@ -202,7 +202,7 @@
     $(document).on('click', '#btnExport', function () {
         var currentDate = new Date();
         var formattedDate = currentDate.toISOString().split('T')[0];
-        var fileName = "Monthly Report - " + formattedDate + ".xlsx";
+        var fileName = "Monthly Report - Export At (" + formattedDate + ").xlsx";
         var requestData = Object.assign({}, data);
         requestData.flag = 1;
         handleExport(url, requestData, fileName);

--- a/resources/views/transpurchase/action.blade.php
+++ b/resources/views/transpurchase/action.blade.php
@@ -1,10 +1,10 @@
 @php
     use Carbon\Carbon;
-    $isCurrentMonth = Carbon::parse($data->date_invoice)->isSameMonth(now());
+    $canModify = Carbon::parse($data->date_invoice)->greaterThanOrEqualTo(Carbon::today()->subDays(20));
 @endphp
 
 @can('Akunting_master_data')
-    @if($isCurrentMonth)
+    @if($canModify)
         <div class="btn-group">
             <button class="btn btn-sm btn-primary action-btn mb-2" data-id="{{ $data->id }}">
                 Action <i class="mdi mdi-chevron-down"></i>

--- a/resources/views/transpurchase/create.blade.php
+++ b/resources/views/transpurchase/create.blade.php
@@ -42,9 +42,14 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ date('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ date('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                             </div>
                             <div class="row">
@@ -120,6 +125,22 @@
                                     <div class="row">
                                         <div class="col-12">
                                             <label class="form-label">List Product</label>
+                                        </div>
+                                        <div class="col-12">
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="text-end d-block d-lg-none">
+                                                <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
+                                                    title="Coretax: ≥0,5 naik, <0,5 turun.">
+                                                </i>
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
                                             <table class="table table-bordered dt-responsive w-100" id="server-side-table" style="font-size: small">
                                                 <thead class="table-light">
                                                     <tr>
@@ -178,7 +199,7 @@
                                                         </td>
                                                         <td class="text-end">
                                                             <label class="form-label"> 
-                                                                <input type="text" name="discount" class="form-control form-control-sm text-end currency-input" value="0">
+                                                                <input type="text" name="discount" class="form-control form-control-sm text-end currency-input-no-comma" value="0">
                                                             </label>
                                                         </td>
                                                     </tr>
@@ -235,7 +256,7 @@
                                                                 </select>
                                                             </td>
                                                             <td>
-                                                                <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
+                                                                <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
                                                             </td>
                                                             <td>
                                                                 <select class="form-select select2 addpayment" style="width: 100%" name="addmore[0][type]" required>
@@ -440,7 +461,7 @@
                     </select>
                 </td>
                 <td>
-                    <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
+                    <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
                 </td>
                 <td>
                     <select class="form-select select2 addpayment" style="width: 100%" name="addmore[`+i+`][type]" required>
@@ -459,8 +480,8 @@
 
         $(".select2").select2();
 
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     });
     $(document).on('click', '.remove-tr', function() {
@@ -501,6 +522,7 @@
                 data: function(d) {
                     d.idGRN   = data.idGRN;
                     d.ppnRate = data.ppnRate;
+                    d.rule    = 'Coretax';
                 }
             },
             columns: [
@@ -544,8 +566,8 @@
                         let price = data ?? 0;
                         return `
                             <input type="text"
-                                class="form-control form-control-sm text-end editable-price currency-input"
-                                value="${numberFormat(price,2,',','.')}"
+                                class="form-control form-control-sm text-end editable-price currency-input-no-comma"
+                                value="${numberFormat(price,0,',','.')}"
                                 data-row="${meta.row}"
                                 data-qty="${row.receipt_qty}">
                         `;
@@ -558,7 +580,7 @@
                         let total = data ?? 0;
                         return `
                             <span class="row-total-price" data-row="${meta.row}">
-                                ${formatPriceWithStyle(total)}
+                                ${formatPriceWithStyleCoretax(total)}
                             </span>
                         `;
                     }
@@ -572,9 +594,9 @@
         dataTable.on('xhr.dt', function(e, settings, json) {
             if (!json) return;
 
-            $('#njPrice').html(formatPriceWithStyle(json.nj ?? 0));
-            $('#ppnPrice').html(formatPriceWithStyle(json.ppn ?? 0));
-            $('#totalPrice').html(formatPriceWithStyle(json.total ?? 0));
+            $('#njPrice').html(formatPriceWithStyleCoretax(json.nj ?? 0));
+            $('#ppnPrice').html(formatPriceWithStyleCoretax(json.ppn ?? 0));
+            $('#totalPrice').html(formatPriceWithStyleCoretax(json.total ?? 0));
             $('#labelPPNRate').html(json.ppn_rate ?? 0);
             $('.currency').html(json.currency ?? 'IDR');
             $('input[name="currency').val(json.currency ?? 'IDR');
@@ -599,7 +621,7 @@
             rowData.price       = priceEdit;
             rowData.total_price = totalRow;
 
-            $('.row-total-price[data-row="'+rowIndex+'"]').html(formatPriceWithStyle(totalRow));
+            $('.row-total-price[data-row="'+rowIndex+'"]').html(formatPriceWithStyleCoretax(totalRow));
             recalculateSummary();
         });
 
@@ -703,9 +725,9 @@
                 $('input[name="discount"]').val() || 0
             );
             let total   = totalNJ + ppn - discount;
-            $('#njPrice').html(formatPriceWithStyle(totalNJ));
-            $('#ppnPrice').html(formatPriceWithStyle(ppn));
-            $('#totalPrice').html(formatPriceWithStyle(total));
+            $('#njPrice').html(formatPriceWithStyleCoretax(totalNJ));
+            $('#ppnPrice').html(formatPriceWithStyleCoretax(ppn));
+            $('#totalPrice').html(formatPriceWithStyleCoretax(total));
             totalPriceGlobal = total ?? 0;
         }
         function formatPrice(value){

--- a/resources/views/transpurchase/edit.blade.php
+++ b/resources/views/transpurchase/edit.blade.php
@@ -41,9 +41,14 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                             </div>
                             <div class="row">
@@ -96,6 +101,22 @@
                                     <div class="row">
                                         <div class="col-12">
                                             <label class="form-label">List Product</label>
+                                        </div>
+                                        <div class="col-12">
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="text-end d-block d-lg-none">
+                                                <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
+                                                    title="Coretax: ≥0,5 naik, <0,5 turun.">
+                                                </i>
+                                            </div>
+                                        </div>
+                                        <div class="col-12">
                                             <table class="table table-bordered dt-responsive w-100" id="server-side-table" style="font-size: small">
                                                 <thead class="table-light">
                                                     <tr>
@@ -154,7 +175,8 @@
                                                         </td>
                                                         <td class="text-end">
                                                             <label class="form-label"> 
-                                                                <input type="text" name="discount" class="form-control form-control-sm text-end currency-input" value="{{ number_format($detail->total_discount, 2, ',', '.') }}">
+                                                                {{-- <input type="text" name="discount" class="form-control form-control-sm text-end currency-input" value="{{ number_format($detail->total_discount, 2, ',', '.') }}"> --}}
+                                                                <input type="text" name="discount" class="form-control form-control-sm text-end currency-input-no-comma" value="{{ number_format(round($detail->total_discount), 0, ',', '.') }}">
                                                             </label>
                                                         </td>
                                                     </tr>
@@ -217,9 +239,10 @@
                                                             </td>
                                                             <td>
                                                                 <input type="text"
-                                                                    class="form-control rupiah-input addpayment"
+                                                                    class="form-control rupiah-input-no-comma addpayment"
                                                                     name="addmore[{{ $index }}][nominal]"
-                                                                    value="{{ number_format($ledger->amount, 2, ',', '.') }}"
+                                                                    {{-- value="{{ number_format($ledger->amount, 2, ',', '.') }}" --}}
+                                                                    value="{{ number_format($ledger->amount, 0, ',', '.') }}"
                                                                     required>
                                                             </td>
                                                             <td>
@@ -416,9 +439,9 @@
 
     function initPlugins() {
         $('.select2').select2({ width: '100%' });
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.removeEventListener("input", formatCurrencyInput);
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.removeEventListener("input", formatCurrencyInputNoComma);
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     }
 
@@ -445,7 +468,7 @@
             </td>
             <td>
                 <input type="text"
-                    class="form-control rupiah-input addpayment"
+                    class="form-control rupiah-input-no-comma addpayment"
                     name="addmore[${i}][nominal]"
                     placeholder="Input Amount.." required>
             </td>
@@ -479,12 +502,6 @@
     $(document).on('click', '.remove-tr', function () {
         $(this).closest('tr').remove();
     });
-
-    // RUPIAH FORMATTER
-    function formatCurrencyInput(e) {
-        let value = e.target.value.replace(/\D/g, '');
-        e.target.value = value.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-    }
 </script>
 
 
@@ -559,8 +576,8 @@
                         let price = data ?? 0;
                         return `
                             <input type="text"
-                                class="form-control form-control-sm text-end editable-price currency-input"
-                                value="${numberFormat(price,2,',','.')}"
+                                class="form-control form-control-sm text-end editable-price currency-input-no-comma"
+                                value="${numberFormat(price,0,',','.')}"
                                 data-row="${meta.row}"
                                 data-qty="${row.receipt_qty}">
                         `;
@@ -573,7 +590,7 @@
                         let total = data ?? 0;
                         return `
                             <span class="row-total-price" data-row="${meta.row}">
-                                ${formatPriceWithStyle(total)}
+                                ${formatPriceWithStyleCoretax(total)}
                             </span>
                         `;
                     }
@@ -587,9 +604,9 @@
         dataTable.on('xhr.dt', function(e, settings, json) {
             if (!json) return;
 
-            $('#njPrice').html(formatPriceWithStyle(json.nj ?? 0));
-            $('#ppnPrice').html(formatPriceWithStyle(json.ppn ?? 0));
-            $('#totalPrice').html(formatPriceWithStyle(json.total ?? 0));
+            $('#njPrice').html(formatPriceWithStyleCoretax(json.nj ?? 0));
+            $('#ppnPrice').html(formatPriceWithStyleCoretax(json.ppn ?? 0));
+            $('#totalPrice').html(formatPriceWithStyleCoretax(json.total ?? 0));
             $('#labelPPNRate').html(json.ppn_rate ?? 0);
             $('.currency').html(json.currency ?? 'IDR');
             $('input[name="currency').val(json.currency ?? 'IDR');
@@ -614,7 +631,7 @@
             rowData.price       = priceEdit;
             rowData.total_price = totalRow;
 
-            $('.row-total-price[data-row="'+rowIndex+'"]').html(formatPriceWithStyle(totalRow));
+            $('.row-total-price[data-row="'+rowIndex+'"]').html(formatPriceWithStyleCoretax(totalRow));
             recalculateSummary();
         });
 
@@ -664,9 +681,9 @@
                 $('input[name="discount"]').val() || 0
             );
             let total   = totalNJ + ppn - discount;
-            $('#njPrice').html(formatPriceWithStyle(totalNJ));
-            $('#ppnPrice').html(formatPriceWithStyle(ppn));
-            $('#totalPrice').html(formatPriceWithStyle(total));
+            $('#njPrice').html(formatPriceWithStyleCoretax(totalNJ));
+            $('#ppnPrice').html(formatPriceWithStyleCoretax(ppn));
+            $('#totalPrice').html(formatPriceWithStyleCoretax(total));
             totalPriceGlobal = total ?? 0;
         }
         function formatPrice(value){

--- a/resources/views/transpurchase/index.blade.php
+++ b/resources/views/transpurchase/index.blade.php
@@ -130,16 +130,16 @@
                                 <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
                                     <ul class="mb-0 ps-3">
                                         <li>
-                                            <b>Edit</b> & <b>Delete</b> actions are only for <b>Super Admin</b> and for transactions in the <b>current month</b>.
+                                            <b>Super Admin</b> can <b>Edit</b> & <b>Delete</b> transactions within <b>20 days</b> only.
                                         </li>
                                         <li>
-                                            When editing, the <b>DN Number</b> cannot be changed. To change it, delete the transaction and create a new one.
+                                            <b>GRN Number</b> cannot be edited. Delete and recreate the transaction to change it.
                                         </li>
                                     </ul>
                                 </div>
                                 <div class="text-end d-block d-lg-none">
                                     <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Edit and Delete actions are only available for Super Admin and only for transactions within the current month & When editing, the GRN Number cannot be changed. To change it, delete the transaction and create a new one.">
+                                        title="Edit and Delete actions are only available for Super Admin. Transactions can only be edited or deleted within 20 days prior to the current date, the DN Number cannot be changed. To change it, delete the transaction and create a new one.">
                                     </i>
                                 </div>
                             </div>

--- a/resources/views/transpurchase/modal/info.blade.php
+++ b/resources/views/transpurchase/modal/info.blade.php
@@ -92,18 +92,20 @@
                                         ({{ $item->unit }})
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->price_edit, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->price_edit), 0, ',', '.') }}</span>
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->total_price, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->total_price), 0, ',', '.') }}</span>
                                     </td>
                                 </tr>
                             @endforeach
@@ -131,11 +133,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> <span class="text-muted">{{ $detail->currency }} </span>
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->amount, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->amount), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -145,11 +148,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> <span class="text-muted">{{ $detail->currency }} </span>
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->ppn_value, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->ppn_value), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -159,11 +163,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> <span class="text-muted">{{ $detail->currency }} </span>
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->total_discount, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->total_discount), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -173,11 +178,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> <span class="text-muted">{{ $detail->currency }} </span>
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->total, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->total), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -219,11 +225,12 @@
                                 {{ $item->account_code." - ".$item->account_name }}
                             </td>
                             <td class="text-end">
-                                @php
+                                {{-- @php
                                     $formatted = number_format($item->amount, 2, ',', '.');
                                     [$before, $after] = explode(',', $formatted);
                                 @endphp
-                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                <span class="fw-bold">{{ number_format(round($item->amount), 0, ',', '.') }}</span>
                             </td>
                             <td class="text-center">
                                 @if($item->transaction == 'D')

--- a/resources/views/transpurchase/modal/list_transaction.blade.php
+++ b/resources/views/transpurchase/modal/list_transaction.blade.php
@@ -27,11 +27,12 @@
                         {{ $item->account_name ?? '-' }}
                     </td>
                     <td class="align-top text-end">
-                        @php
+                        {{-- @php
                             $formatted = number_format($item->amount, 2, ',', '.');
                             [$before, $after] = explode(',', $formatted);
                         @endphp
-                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                        <span class="fw-bold">{{ number_format(round($item->amount), 0, ',', '.') }}</span>
                     </td>
                     <td class="align-top text-center">
                         @if($item->transaction == 'D')

--- a/resources/views/transsales/local/action.blade.php
+++ b/resources/views/transsales/local/action.blade.php
@@ -1,6 +1,6 @@
 @php
     use Carbon\Carbon;
-    $isCurrentMonth = Carbon::parse($data->date_invoice)->isSameMonth(now());
+    $canModify = Carbon::parse($data->date_invoice)->greaterThanOrEqualTo(Carbon::today()->subDays(20));
 @endphp
 
 <div class="btn-group">
@@ -16,7 +16,7 @@
         <span>Info</span>
     </a>
     @can('Akunting_master_data')
-        @if($isCurrentMonth)
+        @if($canModify)
             <hr class="m-0">
             <a href="{{ route('transsales.local.edit', encrypt($data->id)) }}" class="dropdown-item-floating d-flex align-items-center gap-2">
                 <i class="mdi mdi-file-edit"></i>

--- a/resources/views/transsales/local/create.blade.php
+++ b/resources/views/transsales/local/create.blade.php
@@ -42,13 +42,18 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Pilih tanggal yang akan ditampilkan pada invoice. Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Pilih tanggal invoice. Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ date('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ date('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                                 <div class="col-lg-3 mb-3">
                                     <label class="form-label required-label">Due Date</label>
-                                    <input type="date" class="form-control" name="due_date" value="" required min="{{ date('Y-m-01') }}">
+                                    <input type="date" class="form-control" name="due_date" value="" required min="{{ date('Y-m-d', strtotime('-20 days')) }}">
                                 </div>
                                 <div class="col-lg-6 mb-3">
                                     <label class="form-label required-label">Bank Account</label>
@@ -107,7 +112,20 @@
                                             <i class="mdi mdi-information-outline" data-bs-toggle="tooltip" data-bs-placement="top" title="Otomatis terisi dari DN yang dipilih (diambil dari pengisian sales order)"></i>
                                             <input class="form-control readonly-input" id="sales_name" type="text" value="" placeholder="Select Delivery Notes.." readonly>
                                         </div>
-                                        
+                                        <div class="col-12">
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="text-end d-block d-lg-none">
+                                                <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
+                                                    title="Coretax: ≥0,5 naik, <0,5 turun.">
+                                                </i>
+                                            </div>
+                                        </div>
                                         <div class="col-12">
                                             <table class="table table-bordered dt-responsive w-100" id="server-side-table" style="font-size: small">
                                                 <thead class="table-light">
@@ -230,7 +248,7 @@
                                                                 </select>
                                                             </td>
                                                             <td>
-                                                                <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
+                                                                <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[0][nominal]" value="" required>
                                                             </td>
                                                             <td>
                                                                 <select class="form-select select2 addpayment" style="width: 100%" name="addmore[0][type]" required>
@@ -413,7 +431,7 @@
                     </select>
                 </td>
                 <td>
-                    <input type="text" class="form-control rupiah-input addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
+                    <input type="text" class="form-control rupiah-input-no-comma addpayment" style="width: 100%" placeholder="Input Amount.." name="addmore[`+i+`][nominal]" value="" required>
                 </td>
                 <td>
                     <select class="form-select select2 addpayment" style="width: 100%" name="addmore[`+i+`][type]" required>
@@ -432,8 +450,8 @@
 
         $(".select2").select2();
 
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     });
     $(document).on('click', '.remove-tr', function() {
@@ -469,6 +487,7 @@
                 data: function(d) {
                     d.idDN      = data.idDN;
                     d.ppnRate   = data.ppnRate;
+                    d.rule      = 'Coretax';
                 }
             },
             "columns": [
@@ -539,9 +558,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -557,9 +576,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span><br>(' + row.ppn_rate + '%)';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span><br>(' + row.ppn_rate + '%)';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span><br>(' + row.ppn_rate + '%)';
                     },
                 },
@@ -575,9 +594,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -593,9 +612,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -611,9 +630,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -622,10 +641,10 @@
 
         dataTable.on('xhr.dt', function(e, settings, json, xhr) {
             if (json) {
-                $('#njPrice').html(json.nj ? formatPriceWithStyle(json.nj) : 0);
-                $('#dppPrice').html(json.dpp ? formatPriceWithStyle(json.dpp) : 0);
-                $('#ppnPrice').html(json.ppn ? formatPriceWithStyle(json.ppn) : 0);
-                $('#totalPrice').html(json.total ? formatPriceWithStyle(json.total) : 0);
+                $('#njPrice').html(json.nj ? formatPriceWithStyleCoretax(json.nj) : 0);
+                $('#dppPrice').html(json.dpp ? formatPriceWithStyleCoretax(json.dpp) : 0);
+                $('#ppnPrice').html(json.ppn ? formatPriceWithStyleCoretax(json.ppn) : 0);
+                $('#totalPrice').html(json.total ? formatPriceWithStyleCoretax(json.total) : 0);
                 $('#labelPPNRate').html(json.ppn_rate ?? 0);
                 totalPriceGlobal = formatPrice(json.total) || 0;
             }

--- a/resources/views/transsales/local/edit.blade.php
+++ b/resources/views/transsales/local/edit.blade.php
@@ -42,13 +42,18 @@
                                     <label class="form-label required-label">Invoice Date</label>
                                     <i class="mdi mdi-information-outline"
                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Pilih tanggal yang akan ditampilkan pada invoice. Tanggal hanya dapat dipilih dari awal bulan ini hingga hari ini.">
+                                        title="Pilih tanggal invoice. Tanggal hanya dapat dipilih maksimal 20 hari ke belakang dari hari ini dan tidak boleh melebihi tanggal hari ini.">
                                     </i>
-                                    <input type="date" class="form-control" name="date_invoice" value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}" min="{{ date('Y-m-01') }}" max="{{ date('Y-m-d') }}" required>
+                                    <input type="date" class="form-control" name="date_invoice"
+                                        value="{{ \Carbon\Carbon::parse($detail->date_invoice)->format('Y-m-d') }}"
+                                        min="{{ date('Y-m-d', strtotime('-20 days')) }}"
+                                        max="{{ date('Y-m-d') }}"
+                                        required
+                                    >
                                 </div>
                                 <div class="col-lg-3 mb-3">
                                     <label class="form-label required-label">Due Date</label>
-                                    <input type="date" class="form-control" name="due_date" value="{{ \Carbon\Carbon::parse($detail->due_date)->format('Y-m-d') }}" required min="{{ date('Y-m-01') }}">
+                                    <input type="date" class="form-control" name="due_date" value="{{ \Carbon\Carbon::parse($detail->due_date)->format('Y-m-d') }}" required min="{{ date('Y-m-d', strtotime('-20 days')) }}">
                                 </div>
                                 <div class="col-lg-6 mb-3">
                                     <label class="form-label required-label">Bank Account</label>
@@ -90,6 +95,20 @@
                                         <div class="col-lg-6 mb-3">
                                             <label class="form-label">Sales Name</label>
                                             <input class="form-control readonly-input" id="sales_name" type="text" value="{{ $detailCust->salesman_name ?? '-' }}" placeholder="Select Delivery Notes.." readonly>
+                                        </div>
+                                        <div class="col-12">
+                                            <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
+                                                <ul class="mb-0 ps-3">
+                                                    <li>
+                                                        <b>Coretax rule:</b> Jika desimal ≥ 0,5 dibulatkan ke atas, jika < 0,5 dibulatkan ke bawah.
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="text-end d-block d-lg-none">
+                                                <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
+                                                    title="Coretax: ≥0,5 naik, <0,5 turun.">
+                                                </i>
+                                            </div>
                                         </div>
                                         
                                         <div class="col-12">
@@ -219,9 +238,10 @@
                                                             </td>
                                                             <td>
                                                                 <input type="text"
-                                                                    class="form-control rupiah-input addpayment"
+                                                                    class="form-control rupiah-input-no-comma addpayment"
                                                                     name="addmore[{{ $index }}][nominal]"
-                                                                    value="{{ number_format($ledger->amount, 2, ',', '.') }}"
+                                                                    {{-- value="{{ number_format($ledger->amount, 2, ',', '.') }}" --}}
+                                                                    value="{{ number_format($ledger->amount, 0, ',', '.') }}"
                                                                     required>
                                                             </td>
                                                             <td>
@@ -406,9 +426,9 @@
 
     function initPlugins() {
         $('.select2').select2({ width: '100%' });
-        document.querySelectorAll(".rupiah-input").forEach((input) => {
-            input.removeEventListener("input", formatCurrencyInput);
-            input.addEventListener("input", formatCurrencyInput);
+        document.querySelectorAll(".rupiah-input-no-comma").forEach((input) => {
+            input.removeEventListener("input", formatCurrencyInputNoComma);
+            input.addEventListener("input", formatCurrencyInputNoComma);
         });
     }
 
@@ -435,7 +455,7 @@
             </td>
             <td>
                 <input type="text"
-                    class="form-control rupiah-input addpayment"
+                    class="form-control rupiah-input-no-comma addpayment"
                     name="addmore[${i}][nominal]"
                     placeholder="Input Amount.." required>
             </td>
@@ -469,12 +489,6 @@
     $(document).on('click', '.remove-tr', function () {
         $(this).closest('tr').remove();
     });
-
-    // RUPIAH FORMATTER
-    function formatCurrencyInput(e) {
-        let value = e.target.value.replace(/\D/g, '');
-        e.target.value = value.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-    }
 </script>
 
 
@@ -506,6 +520,7 @@
                 data: function(d) {
                     d.idDN      = data.idDN;
                     d.ppnRate   = data.ppnRate;
+                    d.rule      = 'Coretax';
                 }
             },
             "columns": [
@@ -576,9 +591,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -594,9 +609,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span><br>(' + row.ppn_rate + '%)';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span><br>(' + row.ppn_rate + '%)';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span><br>(' + row.ppn_rate + '%)';
                     },
                 },
@@ -612,9 +627,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -630,9 +645,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -648,9 +663,9 @@
                         }
                         var formattedAmount = numberFormat(data, 2, ',', '.'); 
                         var parts = formattedAmount.split(',');
-                        if (parts.length > 1) {
-                            return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                        }
+                        // if (parts.length > 1) {
+                        //     return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+                        // }
                         return '<span class="text-bold">' + parts[0] + '</span>';
                     },
                 },
@@ -659,10 +674,10 @@
 
         dataTable.on('xhr.dt', function(e, settings, json, xhr) {
             if (json) {
-                $('#njPrice').html(json.nj ? formatPriceWithStyle(json.nj) : 0);
-                $('#dppPrice').html(json.dpp ? formatPriceWithStyle(json.dpp) : 0);
-                $('#ppnPrice').html(json.ppn ? formatPriceWithStyle(json.ppn) : 0);
-                $('#totalPrice').html(json.total ? formatPriceWithStyle(json.total) : 0);
+                $('#njPrice').html(json.nj ? formatPriceWithStyleCoretax(json.nj) : 0);
+                $('#dppPrice').html(json.dpp ? formatPriceWithStyleCoretax(json.dpp) : 0);
+                $('#ppnPrice').html(json.ppn ? formatPriceWithStyleCoretax(json.ppn) : 0);
+                $('#totalPrice').html(json.total ? formatPriceWithStyleCoretax(json.total) : 0);
                 $('#labelPPNRate').html(json.ppn_rate ?? 0);
                 totalPriceGlobal = formatPrice(json.total) || 0;
             }

--- a/resources/views/transsales/local/index.blade.php
+++ b/resources/views/transsales/local/index.blade.php
@@ -107,16 +107,16 @@
                                 <div class="alert alert-warning mb-0 d-none d-lg-block" style="font-size:0.5rem;" role="alert">
                                     <ul class="mb-0 ps-3">
                                         <li>
-                                            <b>Edit</b> & <b>Delete</b> actions are only for <b>Super Admin</b> and for transactions in the <b>current month</b>.
+                                            <b>Super Admin</b> can <b>Edit</b> & <b>Delete</b> transactions within <b>20 days</b> only.
                                         </li>
                                         <li>
-                                            When editing, the <b>DN Number</b> cannot be changed. To change it, delete the transaction and create a new one.
+                                            <b>DN Number</b> cannot be edited. Delete and recreate the transaction to change it.
                                         </li>
                                     </ul>
                                 </div>
                                 <div class="text-end d-block d-lg-none">
                                     <i class="mdi mdi-information-outline text-muted" data-bs-toggle="tooltip" data-bs-placement="top"
-                                        title="Edit and Delete actions are only available for Super Admin and only for transactions within the current month & When editing, the DN Number cannot be changed. To change it, delete the transaction and create a new one.">
+                                        title="Edit and Delete actions are only available for Super Admin. Transactions can only be edited or deleted within 20 days prior to the current date, the DN Number cannot be changed. To change it, delete the transaction and create a new one.">
                                     </i>
                                 </div>
                             </div>
@@ -214,22 +214,29 @@
         },
         {
             data: 'total',
-            name: 'total',
             orderable: true,
             searchable: true,
-            className: 'text-end',
-            render: function(data, type, row) {
-                if (data == null) {
-                    return '<span class="badge bg-secondary">Null</span>';
-                }
-                var formattedAmount = numberFormat(data, 2, ',', '.'); 
-                var parts = formattedAmount.split(',');
-                if (parts.length > 1) {
-                    return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
-                }
-                return '<span class="text-bold">' + parts[0] + '</span>';
-            },
+            className: 'align-top text-end',
+            render: (data, type, row) => formatAmountDTCoretax(data),
         },
+        // {
+        //     data: 'total',
+        //     name: 'total',
+        //     orderable: true,
+        //     searchable: true,
+        //     className: 'text-end',
+        //     render: function(data, type, row) {
+        //         if (data == null) {
+        //             return '<span class="badge bg-secondary">Null</span>';
+        //         }
+        //         var formattedAmount = numberFormat(data, 2, ',', '.'); 
+        //         var parts = formattedAmount.split(',');
+        //         if (parts.length > 1) {
+        //             return '<span class="text-bold">' + parts[0] + '</span><span class="text-muted">,' + parts[1] + '</span>';
+        //         }
+        //         return '<span class="text-bold">' + parts[0] + '</span>';
+        //     },
+        // },
         {
             data: 'created_by',
             searchable: true,

--- a/resources/views/transsales/local/modal/info.blade.php
+++ b/resources/views/transsales/local/modal/info.blade.php
@@ -111,40 +111,45 @@
                                     </td>
                                     <td class="text-center">{{ $item->ppn_type }}</td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->price_before_ppn, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->price_before_ppn), 0, ',', '.') }}</span>
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->ppn_value, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->ppn_value), 0, ',', '.') }}</span>
                                         <br>({{ $item->ppn_rate }}%)
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->price_after_ppn, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->price_after_ppn), 0, ',', '.') }}</span>
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->total_price_before_ppn, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->total_price_before_ppn), 0, ',', '.') }}</span>
                                     </td>
                                     <td class="text-end">
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($item->total_price_after_ppn, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($item->total_price_after_ppn), 0, ',', '.') }}</span>
                                     </td>
                                 </tr>
                             @endforeach
@@ -172,11 +177,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> Rp. 
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->sales_value, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->sales_value), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -186,11 +192,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> Rp. 
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->dpp, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->dpp), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -200,11 +207,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> Rp. 
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->ppn_value, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->ppn_value), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -214,11 +222,12 @@
                                 </td>
                                 <td class="text-end">
                                     <label class="form-label"> Rp. 
-                                        @php
+                                        {{-- @php
                                             $formatted = number_format($detail->total, 2, ',', '.');
                                             [$before, $after] = explode(',', $formatted);
                                         @endphp
-                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                        <span class="fw-bold">{{ number_format(round($detail->total), 0, ',', '.') }}</span>
                                     </label>
                                 </td>
                             </tr>
@@ -251,11 +260,12 @@
                                 {{ $item->account_code." - ".$item->account_name }}
                             </td>
                             <td class="text-end">
-                                @php
+                                {{-- @php
                                     $formatted = number_format($item->amount, 2, ',', '.');
                                     [$before, $after] = explode(',', $formatted);
                                 @endphp
-                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                                <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                                <span class="fw-bold">{{ number_format(round($item->amount), 0, ',', '.') }}</span>
                             </td>
                             <td class="text-center">
                                 @if($item->transaction == 'D')

--- a/resources/views/transsales/local/modal/list_transaction.blade.php
+++ b/resources/views/transsales/local/modal/list_transaction.blade.php
@@ -27,11 +27,12 @@
                         {{ $item->account_name ?? '-' }}
                     </td>
                     <td class="align-top text-end">
-                        @php
+                        {{-- @php
                             $formatted = number_format($item->amount, 2, ',', '.');
                             [$before, $after] = explode(',', $formatted);
                         @endphp
-                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span>
+                        <span class="fw-bold">{{ $before }}</span><span class="text-muted">,{{ $after }}</span> --}}
+                        <span class="fw-bold">{{ number_format(round($item->amount), 0, ',', '.') }}</span>
                     </td>
                     <td class="align-top text-center">
                         @if($item->transaction == 'D')


### PR DESCRIPTION
… report

- Sales Local, Purchase, Cashbook modules:
  1. Allow invoice date backdating up to 20 days (created by user)
  2. Restrict update and delete actions within 20 days window (Super Admin only)
  3. Apply Coretax rounding rules to all transactions
  4. Cashbook transaction numbers use Roman numeral based on invoice month

- Daily Sync Report:
  1. Support backdated transactions up to 20 days
  2. Allow updates to previous month transactions within 20 days window
  3. Sync process recalculates data for the last two months to ensure accuracy